### PR TITLE
test(triage): add issue validation diagnostics — no fixes

### DIFF
--- a/docs/issue-validation-triage-2026-01-29.md
+++ b/docs/issue-validation-triage-2026-01-29.md
@@ -1,0 +1,30 @@
+# Issue validation triage — 2026-01-29
+
+Automated validation run results for issues listed in `data/issues-todo.json` (see `tmp/validate-and-mark-fixed-summary-1769740705791.json` for raw output).
+
+Summary
+- Run time: 2026-01-29T20:41:45-06:00
+- Inspected: 24 issues
+- Marked fixed: 0
+- Tests failed: 11
+- No test present: 12
+
+Top failing validations
+- `note-1769470023977-p0` — Playwright: "No tests found" (test harness mismatch)
+- `note-1769306014994-p0` — Playwright: "No tests found"
+- `note-1769305932956-p0` — Playwright: "No tests found"
+- `note-1769302437975-p0` — Playwright: "No tests found"
+- `note-1769220751805-p0` — Playwright: "No tests found"
+
+Conclusion
+- No issue met the "validation test passed" requirement, so none were marked `fixed:true`.
+- Next actionable work: collect Playwright traces for the failing tests, triage the cause (missing test, brittle selector, or genuine app bug), and create low-risk fix PRs.
+
+Artifacts
+- Raw summary: `tmp/validate-and-mark-fixed-summary-1769740705791.json`
+
+Proposed immediate action (automated)
+1. Capture Playwright traces for the top 6 failing tests and attach them to a draft PR.
+2. Attempt low-risk fixes for "test-harness" problems (missing assertions, test file name mismatches) and open separate PRs for any safe fixes.
+
+If you want me to proceed I will push these diagnostics to a draft PR and start triage PRs for the easiest failures.


### PR DESCRIPTION
Automated validation run for `data/issues-todo.json` issue tests.

What I did:
- Ran validation tests for issues that have test files
- Saved summary and triage notes in `docs/issue-validation-triage-2026-01-29.md`
- Did NOT mark any issue `fixed:true` because no validation test passed

Findings:
- 0 issues passed validation
- 11 tests failed (Playwright reported no runnable tests or failures)
- 12 issues have no associated test file

Next steps (suggested):
- Capture Playwright traces for failing tests and attach to follow-up PR(s)
- Fix missing/brittle tests and re-run validations

This PR contains diagnostics only (no code changes).