### PR TITLE
feat(types): add narrow interfaces for wb-card APIs

### DIFF
--- a/src/types/wb-card.d.ts
+++ b/src/types/wb-card.d.ts
@@ -1,0 +1,41 @@
+// Narrow typings for wb-card runtime APIs — replace temporary any in stages.
+// Small, focused surface area for reviewers to validate behavior signatures.
+
+declare global {
+  /** API exposed on <element>.wbCardExpandable */
+  interface WBCardExpandableAPI {
+    expand(): void;
+    collapse(): void;
+    toggle(): void;
+    readonly expanded: boolean | undefined;
+  }
+
+  /** API exposed on <element>.wbCardMinimizable */
+  interface WBCardMinimizableAPI {
+    toggle(): void;
+    minimize(): void;
+    expand(): void;
+    readonly minimized: boolean | undefined;
+  }
+
+  /** API exposed on <element>.wbCardDraggable */
+  interface WBCardDraggableAPI {
+    setPosition(x: number, y: number): void;
+    getPosition(): { x: number; y: number };
+    reset(): void;
+  }
+
+  /** API exposed on portfolio-like cards */
+  interface WBPortfolioAPI {
+    setAvailability(status: string): void;
+  }
+
+  interface HTMLElement {
+    wbCardExpandable?: WBCardExpandableAPI;
+    wbCardMinimizable?: WBCardMinimizableAPI;
+    wbCardDraggable?: WBCardDraggableAPI;
+    wbPortfolio?: WBPortfolioAPI;
+  }
+}
+
+export {};

--- a/src/types/wb-elements.d.ts
+++ b/src/types/wb-elements.d.ts
@@ -1,0 +1,40 @@
+// Type augmentations for WB Framework
+
+declare global {
+  interface HTMLElement {
+    wbCardExpandable?: WBCardExpandableAPI;
+    wbCardMinimizable?: WBCardMinimizableAPI;
+    wbCardDraggable?: WBCardDraggableAPI;
+    wbPortfolio?: WBPortfolioAPI;
+    wbCodeControl?: any;
+    wbCollapse?: any;
+    wbConfetti?: any;
+    wbTypewriter?: any;
+    wbCountup?: any;
+    wbSparkle?: any;
+    wbFireworks?: any;
+    wbSnow?: any;
+    wbForm?: any;
+    wbToggle?: any;
+    wbMdhtml?: any;
+    wbVideo?: any;
+    wbAudio?: any;
+    wbDrawer?: any;
+    wbOffcanvas?: any;
+    wbSheet?: any;
+    wbResizable?: any;
+    wbStageLight?: any;
+    wbSticky?: any;
+    wbThemeControl?: any;
+    wbNotes?: any;
+    wbValidator?: any;
+    wbVisible?: any;
+    _wbTooltip?: any;
+    _wbSpinnerInit?: boolean;
+    _statusTimeout?: number;
+
+    items?: any[];
+  }
+}
+
+export {};


### PR DESCRIPTION
What
- Introduce precise TypeScript interfaces for the `wb-card` runtime APIs:
  - `WBCardExpandableAPI`, `WBCardMinimizableAPI`, `WBCardDraggableAPI`, `WBPortfolioAPI`
- Replace the broad `any` ambient declarations with these narrow interfaces in `src/types`.

Why
- Removes incorrect `any` widenings that hide real type errors.
- Enables targeted, safe tightening of the `card` implementation and its consumers.

Scope & risk
- Low risk: this PR is purely typing-first (no runtime logic changes).
- If CI surfaces usages that don't match the API, I'll fix call sites in follow-ups.

Validation
- Ran local `npm run typecheck` with no errors.
- Local smoke tests (cards/media/forms) pass on top of the migration branch.

Follow-ups (suggested)
1. Narrow `wb-input` and `wb-media` ambient typings next (I can prepare PRs).
2. Replace remaining `any` casts in `src/wb-viewmodels/card.ts` with concrete types.

Notes for reviewers
- Focus review on the interface method signatures and return types (these should match the runtime behavior).