### PR TITLE
chore(ci): add manual-compliance workflow_dispatch + HOWTO (publish Playwright traces)

### DIFF
--- a/.github/workflows/manual-compliance.yml
+++ b/.github/workflows/manual-compliance.yml
@@ -1,0 +1,82 @@
+name: Manual Compliance (dispatch)
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Git ref to run the workflow on'
+        required: false
+        default: 'main'
+      tests:
+        description: 'Playwright test path or pattern (optional)'
+        required: false
+        default: ''
+      trace:
+        description: 'Enable Playwright traces'
+        required: false
+        default: 'true'
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  run-compliance:
+    name: Run focused compliance (with artifacts)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: |
+          npm ci
+          npx playwright install --with-deps
+
+      - name: Run Playwright (focused)
+        id: run
+        run: |
+          set -e
+          REF="${{ github.event.inputs.ref || github.ref }}"
+          echo "Running tests on ref: ${REF}"
+          if [ -n "${{ github.event.inputs.tests }}" ]; then
+            TEST_CMD="npx playwright test ${{ github.event.inputs.tests }} --reporter=list"
+          else
+            TEST_CMD="npx playwright test --project=compliance --reporter=list"
+          fi
+          if [ "${{ github.event.inputs.trace }}" = 'true' ]; then
+            TEST_CMD="$TEST_CMD --trace=on"
+          fi
+          echo "$TEST_CMD"
+          eval "$TEST_CMD"
+        shell: bash
+
+      - name: Collect artifacts (trace + logs)
+        if: always()
+        run: |
+          mkdir -p artifacts || true
+          # copy common Playwright outputs
+          cp -v data/test-results/**/*.zip artifacts/ 2>/dev/null || true
+          cp -v data/test-results/**/*.log artifacts/ 2>/dev/null || true
+          cp -v data/test-results/.last-run.json artifacts/ 2>/dev/null || true
+          ls -la artifacts || true
+
+      - name: Upload Playwright traces & logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: artifacts/**
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "CI: Playwright focused run complete. Artifacts uploaded as 'playwright-traces' if present."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,37 @@ npm run test:compliance
 npm run test:ui
 ```
 
+### Producing and publishing Playwright artifacts (traces) 🔍
+
+- Quick local repro (produces `trace.zip`):
+
+```bash
+# focused compliance (local)
+npx playwright test tests/compliance/no-observer-referror.spec.ts \
+  --trace=on --reporter=list
+
+# or run a named compliance project
+npx playwright test --project=compliance --trace=on
+```
+
+- Where to find artifacts locally:
+  - `data/test-results/**/trace.zip`
+  - `data/test-results/.last-run.json`
+  - `data/test-results/.../run.log`
+
+- How to publish/download artifacts on CI:
+  - Use the **Manual Compliance** workflow (Actions → Manual Compliance) to run focused tests on any ref and upload `trace.zip` automatically.
+  - Or ask maintainers to re-run the PR workflow; artifacts will appear under the job **Artifacts** panel.
+
+- Quick GH CLI (manual run):
+
+```bash
+# open the Actions UI for the repo and select 'Manual Compliance'
+# or use gh to dispatch (if workflow supports it):
+gh workflow run "Manual Compliance (dispatch)" -f ref=main -f tests="tests/compliance/no-observer-referror.spec.ts" -f trace=true
+```
+
+Please attach the generated `trace.zip` to the PR when reporting flaky failures.
 ## Code Quality Rules
 
 1. **No broken links** - All CSS/JS/image paths must be valid


### PR DESCRIPTION
Why
----
Debugging Playwright regressions requires trace artifacts (`trace.zip`) but CI does not consistently publish them for focused runs. This adds a manual, auditable way for maintainers to run focused compliance tests with traces and upload the artifacts.

What I changed
-------------
- Add `.github/workflows/manual-compliance.yml` — supports `workflow_dispatch` to run focused compliance tests (with `--trace=on`) and uploads trace/log artifacts.
- Update `CONTRIBUTING.md` with a short HOWTO showing how to produce and publish Playwright traces locally and via Actions.

How reviewers can use this
-------------------------
1. Open the **Actions** tab → **Manual Compliance (dispatch)** workflow → Run workflow on any ref (e.g., `main`) and specify `tests` and `trace=true`.
2. After the job completes, download `playwright-traces` artifact from the job details.

Follow-ups
----------
- Recommend updating CI to automatically upload Playwright traces on failure for the full compliance job (tracked in #47).

Closes: #47
