### PR TITLE
ci: ensure Playwright devDependencies are installed in manual workflow

### DIFF
--- a/.github/workflows/manual-compliance.yml
+++ b/.github/workflows/manual-compliance.yml
@@ -36,9 +36,16 @@ jobs:
         with:
           node-version: '18'
 
-      - name: Install dependencies
+      - name: Install dependencies (ensure dev deps)
         run: |
-          npm ci
+          # Ensure devDependencies (like @playwright/test) are installed even if
+          # runner sets NODE_ENV=production. Try a normal CI install, then force
+          # dev deps if missing.
+          npm ci --no-audit || true
+          if [ ! -d node_modules/@playwright/test ]; then
+            echo "@playwright/test missing — installing devDependencies"
+            npm install --include=dev --no-audit
+          fi
           npx playwright install --with-deps
 
       - name: Run Playwright (focused)


### PR DESCRIPTION
Quick fix for the manual compliance workflow: the runner reported `Cannot find package '@playwright/test'` when executing the dispatched job. This change ensures devDependencies are installed (fallback to `npm install --include=dev`) before running Playwright and should prevent ERR_MODULE_NOT_FOUND for Playwright in Actions.

- Update: `.github/workflows/manual-compliance.yml` — robust `npm ci` + dev-deps fallback

Validation
- Once merged, the `Manual Compliance` workflow should run on `main` and publish `trace.zip` artifacts for focused runs.

Relates-to: #47