### PR TITLE
ci: runtime-install @playwright/test in manual workflow (fix CI focused runs)

### DIFF
--- a/.github/workflows/manual-compliance.yml
+++ b/.github/workflows/manual-compliance.yml
@@ -43,9 +43,11 @@ jobs:
           # dev deps if missing.
           npm ci --no-audit || true
           if [ ! -d node_modules/@playwright/test ]; then
-            echo "@playwright/test missing — installing devDependencies"
-            npm install --include=dev --no-audit
+            echo "@playwright/test missing — installing @playwright/test transiently"
+            npm install --no-audit --no-fund --no-package-lock --save-dev @playwright/test
           fi
+
+          # Ensure Playwright browsers are available
           npx playwright install --with-deps
 
       - name: Run Playwright (focused)


### PR DESCRIPTION
During a dispatched manual run Playwright was missing from the runner (`ERR_MODULE_NOT_FOUND`). The repository does not currently include `@playwright/test` in package.json devDependencies, so CI should be resilient and install the package at runtime for focused/manual runs.

This PR (small, safe) makes the manual workflow resilient by installing `@playwright/test` transiently when missing so reviewers can dispatch focused runs and retrieve trace artifacts. Follow-up: add `@playwright/test` to devDependencies in package.json (tracked separately).