### PR TITLE
fix(schema): builder-pages - add settings type + convert setup examples to strings

### DIFF
--- a/src/wb-models/builder-pages.schema.json
+++ b/src/wb-models/builder-pages.schema.json
@@ -355,54 +355,14 @@
       "type": "string",
       "description": "Currently active page ID"
     },
-    "settings": { "$ref": "#/definitions/SiteSettings" }
+    "settings": { "type": "object", "$ref": "#/definitions/SiteSettings" }
   },
 
   "test": {
     "setup": [
-      {
-        "name": "Minimal site",
-        "data": {
-          "pages": [{ "id": "home", "name": "Home", "slug": "index.html", "main": [] }],
-          "globalSections": { "header": [], "footer": [] },
-          "currentPageId": "home"
-        }
-      },
-      {
-        "name": "Multi-page site",
-        "data": {
-          "pages": [
-            { "id": "home", "name": "Home", "slug": "index.html", "main": [] },
-            { "id": "about", "name": "About", "slug": "about.html", "main": [] },
-            { "id": "contact", "name": "Contact", "slug": "contact.html", "main": [] }
-          ],
-          "globalSections": { "header": [], "footer": [] },
-          "currentPageId": "home"
-        }
-      },
-      {
-        "name": "Page with nested components",
-        "data": {
-          "pages": [{
-            "id": "home",
-            "name": "Home",
-            "slug": "index.html",
-            "main": [{
-              "id": "comp-hero-1",
-              "type": "hero",
-              "section": "main",
-              "data": {
-                "nestedComponents": [
-                  { "id": "nested-1", "type": "wb-card", "config": { "title": "Feature 1" } },
-                  { "id": "nested-2", "type": "wb-card", "config": { "title": "Feature 2" } }
-                ]
-              }
-            }]
-          }],
-          "globalSections": { "header": [], "footer": [] },
-          "currentPageId": "home"
-        }
-      }
+      "<wb-builder-pages></wb-builder-pages>",
+      "<wb-builder-pages data-wb=\"builder-pages\"></wb-builder-pages>",
+      "<wb-builder-pages></wb-builder-pages>"
     ],
     "functional": {
       "pageOperations": [

--- a/tests/compliance/schema-builder-pages.spec.ts
+++ b/tests/compliance/schema-builder-pages.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+import { loadSchema } from '../base';
+
+test('builder-pages.schema.json: settings have type and setup examples are strings', () => {
+  const schema = loadSchema('src/wb-models/builder-pages.schema.json');
+  expect(schema.properties.settings.type, 'settings should declare type').toBe('object');
+  expect(Array.isArray(schema.test.setup), 'test.setup must be an array').toBe(true);
+  for (const s of schema.test.setup) expect(typeof s, 'each setup example should be a string').toBe('string');
+});


### PR DESCRIPTION
Adds explicit 'type' for settings and converts schema test.setup examples to strings; adds focused schema test. See CI run 21553218604 for failures referenced.