### PR TITLE
builder: remove initMenuHandlers shim from binder (small cleanup)

### DIFF
--- a/src/wb-viewmodels/builder-app/builder-dom-init.js
+++ b/src/wb-viewmodels/builder-app/builder-dom-init.js
@@ -7,9 +7,7 @@ function safeAssign(name, fn) {
   if (!window[name]) window[name] = fn;
 }
 
-// MENU HANDLING (delegated)
-function initMenuHandlers() { /* delegated to `builder-menu.js` — kept as noop shim */ }
-
+// MENU HANDLING — fully delegated to `builder-menu.js` (removed noop shim here)
 // autoResizeCanvas delegated to viewmodels
 function autoResizeCanvasImpl() { /* noop — viewmodel should provide real impl */ }
 

--- a/tests/compliance/no-initMenuHandlers.spec.ts
+++ b/tests/compliance/no-initMenuHandlers.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('builder DOM binder does not expose initMenuHandlers shim', async ({ page }) => {
+  await page.goto('/builder.html');
+  const isUndefined = await page.evaluate(() => typeof (window as any).initMenuHandlers === 'undefined');
+  expect(isUndefined).toBe(true);
+});


### PR DESCRIPTION
What

- Remove the leftover noop `initMenuHandlers` shim from `builder-dom-init.js` (menu behavior is provided by `builder-menu.js`).
- Add a focused compliance test to assert `window.initMenuHandlers` is not exposed.

Why

- Tightens the MVVM contract: the DOM binder is now strictly data-on* wiring and harmless shims only; menu implementation lives in the extracted component.
- Small, low-risk cleanup with test coverage to prevent regressions.

Validation

- Local focused tests: `builder-menu` + `no-initMenuHandlers` — all passing.

Notes

- Base for this PR is the ongoing MVVM migration branch so reviewers can see the incremental cleanup.
- This is safe to merge before the full-compliance run finishes; tests are focused and non‑breaking.