### PR TITLE
fix(#42): add home-page.md to docs manifest

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -772,6 +772,11 @@
       "icon": "📄",
       "docs": [
         {
+          "file": "home-page.md",
+          "title": "Home Page",
+          "description": "Documentation for the home page layout"
+        },
+        {
           "file": "DATA-FILES.md",
           "title": "DATA-FILES",
           "description": "Documentation for DATA-FILES"


### PR DESCRIPTION
Adds `home-page.md` to `docs/manifest.json` so `docs-manifest-integrity.spec.ts` passes. Fixes #42 (and the docs-manifest portion of #59).

🤖 Generated with [Claude Code](https://claude.com/claude-code)