### PR TITLE
fix(ci): reuse existing server — stop port 3000 collision

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -66,11 +66,16 @@ export default defineConfig({
     trace: 'off',
   },
   
-  // Web server - automatically starts before tests
+  // Web server - automatically starts before tests.
+  // reuseExistingServer must be true even in CI: ci-tests.yml starts the
+  // server itself (node server.js &) before invoking Playwright, so Playwright
+  // must reuse it rather than trying to bind port 3000 a second time (which
+  // fails with "port 3000 is already used"). When no server is running
+  // (e.g. ci-compliance.yml), Playwright still starts one via `command`.
   webServer: {
     command: 'npm start',
     port: 3000,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: true,
     timeout: 10000,
   },
   


### PR DESCRIPTION
Every CI test job failed with `port 3000 is already used`: ci-tests.yml starts the server manually, then Playwright (reuseExistingServer=!CI=false) tried to start a second one. Set `reuseExistingServer: true` so Playwright reuses the running server. Surfaced only after the lockfile fix (#120) let CI get past install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)