### PR TITLE
fix(doc-viewer): constrain code blocks + add text-size control (#147)

### DIFF
--- a/public/doc-viewer.html
+++ b/public/doc-viewer.html
@@ -50,8 +50,10 @@
     .wb-mdhtml li { margin-bottom: 0.5rem; }
     .wb-mdhtml code { background: var(--bg-tertiary); padding: 0.2rem 0.4rem; border-radius: 4px; font-family: 'JetBrains Mono', 'Fira Code', Consolas, monospace; font-size: 0.9em; color: var(--text-primary); font-weight: 600; }
     .wb-mdhtml a { color: var(--primary-light); text-decoration: underline; }
-    .wb-mdhtml pre { background: var(--bg-secondary); padding: 1rem; border-radius: 8px; overflow-x: auto; margin: 0 auto 1.5rem auto; border: 1px solid var(--border-color); line-height: 1.2; width: fit-content; min-width: 50%; }
-    .wb-mdhtml pre code { background: none; padding: 0; color: var(--text-primary); font-weight: normal !important; font-size: 13px; font-family: Consolas, 'Courier New', monospace; white-space: pre; font-variant-ligatures: none; tab-size: 4; letter-spacing: 0; }
+    .wb-mdhtml pre { background: var(--bg-secondary); padding: 1rem; border-radius: 8px; overflow-x: auto; margin: 0 0 1.5rem 0; border: 1px solid var(--border-color); line-height: 1.2; max-width: 100%; }
+    .wb-mdhtml pre code { background: none; padding: 0; color: var(--text-primary); font-weight: normal !important; font-size: 0.85rem; font-family: Consolas, 'Courier New', monospace; white-space: pre; font-variant-ligatures: none; tab-size: 4; letter-spacing: 0; }
+    .wb-mdhtml .code-wrapper { max-width: 100%; overflow-x: auto; }
+    .wb-mdhtml .code-wrapper pre { max-width: 100%; }
     .wb-mdhtml blockquote { border-left: 4px solid var(--primary); margin: 0 0 1.5rem 0; padding-left: 1rem; color: var(--text-muted); font-style: italic; }
     .wb-mdhtml table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; }
     .wb-mdhtml th, .wb-mdhtml td { padding: 0.75rem; border: 1px solid var(--border-color); text-align: left; }
@@ -62,7 +64,29 @@
   </style>
 </head>
 <body id="doc-viewer-body">
-  <a id="close-button" href="javascript:window.close()" class="back-link">✕ Close</a>
+  <div style="display:flex;gap:0.5rem;align-items:center;margin-bottom:2rem;flex-wrap:wrap;">
+    <a id="close-button" href="javascript:window.close()" class="back-link" style="margin-bottom:0;">✕ Close</a>
+    <button id="text-smaller" class="back-link" style="margin-bottom:0;cursor:pointer;" title="Smaller text" aria-label="Decrease text size">A−</button>
+    <button id="text-larger" class="back-link" style="margin-bottom:0;cursor:pointer;" title="Larger text" aria-label="Increase text size">A+</button>
+    <button id="text-reset" class="back-link" style="margin-bottom:0;cursor:pointer;" title="Reset text size" aria-label="Reset text size">Reset</button>
+  </div>
+  <script>
+    (function () {
+      var KEY = 'wb-doc-font-scale';
+      function clamp(v) { return Math.max(0.7, Math.min(2.0, v)); }
+      function apply(scale) { document.documentElement.style.fontSize = (scale * 100) + '%'; }
+      var scale = clamp(parseFloat(localStorage.getItem(KEY) || '1') || 1);
+      apply(scale);
+      function set(s) { scale = clamp(s); localStorage.setItem(KEY, String(scale)); apply(scale); }
+      document.addEventListener('click', function (e) {
+        var t = e.target;
+        if (!t || !t.id) return;
+        if (t.id === 'text-smaller') { e.preventDefault(); set(scale - 0.1); }
+        else if (t.id === 'text-larger') { e.preventDefault(); set(scale + 0.1); }
+        else if (t.id === 'text-reset') { e.preventDefault(); set(1); }
+      });
+    })();
+  </script>
   <div id="content" class="wb-mdhtml">
     <div id="loading-message" class="loading">Loading documentation...</div>
   </div>

--- a/tests/behaviors/doc-viewer-layout.spec.ts
+++ b/tests/behaviors/doc-viewer-layout.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * doc-viewer: code blocks must not exceed the element/page width, and the
+ * text-size control must change the doc text size (issue #147).
+ */
+import { test, expect } from '@playwright/test';
+
+const URL = '/public/doc-viewer.html?file=%2Fdocs%2Fstandards%2FV3-STANDARDS.md';
+
+test('code blocks do not overflow the page width', async ({ page }) => {
+  await page.goto(URL);
+  await page.waitForFunction(() => {
+    const t = (document.getElementById('content')?.innerText || '');
+    return t.length > 200 && !t.includes('Loading documentation');
+  }, { timeout: 15000 });
+  await page.waitForSelector('pre', { timeout: 10000 });
+
+  // no horizontal page overflow
+  const overflow = await page.evaluate(() => document.documentElement.scrollWidth - document.documentElement.clientWidth);
+  expect(overflow, 'page should not scroll horizontally').toBeLessThanOrEqual(2);
+
+  // every <pre> stays within its container
+  const exceed = await page.evaluate(() => {
+    const body = document.body.clientWidth;
+    return Array.from(document.querySelectorAll('pre')).filter(p => p.getBoundingClientRect().width > body + 2).length;
+  });
+  expect(exceed, 'no <pre> wider than the body').toBe(0);
+});
+
+test('text-size control changes the doc text size', async ({ page }) => {
+  await page.goto(URL);
+  await page.waitForSelector('#text-larger', { timeout: 10000 });
+  const base = await page.evaluate(() => parseFloat(getComputedStyle(document.documentElement).fontSize));
+  await page.locator('#text-larger').click();
+  await page.locator('#text-larger').click();
+  const bigger = await page.evaluate(() => parseFloat(getComputedStyle(document.documentElement).fontSize));
+  expect(bigger).toBeGreaterThan(base);
+  await page.locator('#text-smaller').click();
+  const smaller = await page.evaluate(() => parseFloat(getComputedStyle(document.documentElement).fontSize));
+  expect(smaller).toBeLessThan(bigger);
+  await page.locator('#text-reset').click();
+  const reset = await page.evaluate(() => parseFloat(getComputedStyle(document.documentElement).fontSize));
+  expect(Math.round(reset)).toBe(Math.round(base));
+});


### PR DESCRIPTION
Closes #147 — code blocks no longer overflow the element/page width (constrain .code-wrapper to max-width:100% with internal scroll), and adds working A−/A+/Reset text-size controls (scale root font-size, persisted). Test: tests/behaviors/doc-viewer-layout.spec.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)