### PR TITLE
fix(compliance): strict-mode markers + wb-audio regression tests (#143 partial)

### DIFF
--- a/tests/compliance/strict-mode-runtime.spec.ts
+++ b/tests/compliance/strict-mode-runtime.spec.ts
@@ -26,16 +26,16 @@ test.describe('Strict Mode Runtime Compliance', () => {
 
     // 2. Check that Modern component processed
     const modernCard = page.locator('#modern-card');
-    await expect(modernCard).toHaveAttribute('data-wb-schema', 'card');
+    await expect(modernCard).toHaveAttribute('x-schema', 'card');
 
     // 3. Check that Legacy component is NOT processed/upgraded
     const legacyCard = page.locator('#legacy-card');
     
     // Should verify it has the error marker
-    await expect(legacyCard).toHaveAttribute('data-wb-error', 'legacy');
+    await expect(legacyCard).toHaveAttribute('x-error', 'legacy');
     
     // Should NOT have the success marker
-    const isLegacyProcessed = await legacyCard.evaluate((el: HTMLElement) => el.dataset.wbSchema);
-    expect(isLegacyProcessed).toBeUndefined();
+    const isLegacyProcessed = await legacyCard.getAttribute('x-schema');
+    expect(isLegacyProcessed).toBeNull();
   });
 });

--- a/tests/components/audio.spec.ts
+++ b/tests/components/audio.spec.ts
@@ -1,0 +1,53 @@
+/**
+ * wb-audio regression tests
+ * Covers bug-registry entries:
+ *   BUG-2024-12-19-001 — Audio src set on a div instead of the <audio> element
+ *   BUG-2025-12-26-002 — Audio EQ panel missing controls when show-eq
+ * Source: src/wb-viewmodels/semantics/audio.js (+ wb-audio.js)
+ */
+import { test, expect, Page } from '@playwright/test';
+
+const BASE_URL = '/demos/test-harness.html';
+
+async function setup(page: Page, html: string): Promise<void> {
+  await page.goto(BASE_URL);
+  await page.waitForFunction(
+    () => (window as any).WB && (window as any).WB.behaviors,
+    { timeout: 12000 }
+  );
+  await page.evaluate((h: string) => {
+    const c = document.createElement('div');
+    c.id = 'audio-test';
+    c.innerHTML = h;
+    document.body.appendChild(c);
+  }, html);
+  await page.evaluate(() => (window as any).WB.scan(document.getElementById('audio-test')));
+  await page.waitForTimeout(600);
+}
+
+test.describe('wb-audio', () => {
+  // BUG-2024-12-19-001
+  test('src is applied to the inner <audio> element (not a div)', async ({ page }) => {
+    await setup(page, '<wb-audio id="a-src" src="/demos/audio.mp3"></wb-audio>');
+    const host = page.locator('#a-src');
+    const audio = host.locator('audio');
+    await expect(audio).toHaveCount(1);
+    const src = await audio.evaluate((el) => (el as HTMLAudioElement).getAttribute('src') || (el as HTMLAudioElement).src);
+    expect(src).toContain('audio.mp3');
+  });
+
+  // BUG-2025-12-26-002
+  test('show-eq renders the equalizer band controls', async ({ page }) => {
+    await setup(page, `
+      <wb-audio id="a-plain" src="/demos/audio.mp3"></wb-audio>
+      <wb-audio id="a-eq" src="/demos/audio.mp3" show-eq></wb-audio>
+    `);
+    // EQ panel renders shortly after scan — wait for the band sliders to appear
+    await page.locator('#a-eq input[type="range"]').first().waitFor({ state: 'attached', timeout: 6000 });
+    const eqSliders = await page.locator('#a-eq input[type="range"]').count();
+    const plainSliders = await page.locator('#a-plain input[type="range"]').count();
+    // 15-band EQ -> many sliders when show-eq, and more than the plain player
+    expect(eqSliders, 'show-eq should render band sliders').toBeGreaterThanOrEqual(10);
+    expect(eqSliders).toBeGreaterThan(plainSliders);
+  });
+});


### PR DESCRIPTION
Resolves 3 of 4 parts of #143: strict-mode marker alignment (x-schema/x-error), wb-audio regression test (bug-registry file), error-log now clean. Remaining home-page CTA/glass-card is a landing-page design decision — #143 stays open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)