### PR TITLE
fix(doc-viewer): wrap code instead of horizontal scroll (follow-up #147)

### DIFF
--- a/public/doc-viewer.html
+++ b/public/doc-viewer.html
@@ -50,9 +50,9 @@
     .wb-mdhtml li { margin-bottom: 0.5rem; }
     .wb-mdhtml code { background: var(--bg-tertiary); padding: 0.2rem 0.4rem; border-radius: 4px; font-family: 'JetBrains Mono', 'Fira Code', Consolas, monospace; font-size: 0.9em; color: var(--text-primary); font-weight: 600; }
     .wb-mdhtml a { color: var(--primary-light); text-decoration: underline; }
-    .wb-mdhtml pre { background: var(--bg-secondary); padding: 1rem; border-radius: 8px; overflow-x: auto; margin: 0 0 1.5rem 0; border: 1px solid var(--border-color); line-height: 1.2; max-width: 100%; }
-    .wb-mdhtml pre code { background: none; padding: 0; color: var(--text-primary); font-weight: normal !important; font-size: 0.85rem; font-family: Consolas, 'Courier New', monospace; white-space: pre; font-variant-ligatures: none; tab-size: 4; letter-spacing: 0; }
-    .wb-mdhtml .code-wrapper { max-width: 100%; overflow-x: auto; }
+    .wb-mdhtml pre { background: var(--bg-secondary); padding: 1rem; border-radius: 8px; overflow-x: hidden; margin: 0 0 1.5rem 0; border: 1px solid var(--border-color); line-height: 1.2; max-width: 100%; }
+    .wb-mdhtml pre code { background: none; padding: 0; color: var(--text-primary); font-weight: normal !important; font-size: 0.85rem; font-family: Consolas, 'Courier New', monospace; white-space: pre-wrap; overflow-wrap: anywhere; word-break: break-word; font-variant-ligatures: none; tab-size: 4; letter-spacing: 0; }
+    .wb-mdhtml .code-wrapper { max-width: 100%; overflow-x: hidden; }
     .wb-mdhtml .code-wrapper pre { max-width: 100%; }
     .wb-mdhtml blockquote { border-left: 4px solid var(--primary); margin: 0 0 1.5rem 0; padding-left: 1rem; color: var(--text-muted); font-style: italic; }
     .wb-mdhtml table { width: 100%; border-collapse: collapse; margin-bottom: 1.5rem; }


### PR DESCRIPTION
Doc-viewer code blocks now wrap (white-space:pre-wrap) instead of horizontal-scrolling — better with the text-size control. Verified by tests/behaviors/doc-viewer-layout.spec.ts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)