### PR TITLE
fix(home): CTA section + glass card (#143)

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -59,3 +59,10 @@
   <wb-cardnotification variant="error" title="Failure" message="Something went wrong."></wb-cardnotification>
 </wb-stack>
 <wb-audio src="/demos/sample.wav" show-eq volume="0.5"></wb-audio>
+
+<h2>Ready to build something?</h2>
+<wb-card variant="glass">
+  <p>Grab the components or dive into the docs — no build step required.</p>
+  <a href="?page=components" class="wb-btn wb-btn--primary">Get Started</a>
+  <a href="https://github.com/CieloVistaSoftware/wb-starter" class="wb-btn wb-btn--secondary">GitHub</a>
+</wb-card>


### PR DESCRIPTION
Closes #143. Adds the Ready-to-build CTA (h2 + Get Started + GitHub links) and the glass-card demo that page-compliance requires on /. The other 3 parts of #143 landed in #149.