### PR TITLE
fix(behaviors): dedup description text + remove overlapping theme control (#155)

### DIFF
--- a/pages/behaviors.html
+++ b/pages/behaviors.html
@@ -9,7 +9,6 @@
 <div class="page__section">
 
     </div>
-    <wb-themecontrol></wb-themecontrol>
   </header>
   <nav id="nav" class="nav-links"><a href="#buttons">🔘 Buttons</a>
     <a href="#inputs">📝 Inputs</a>
@@ -29,7 +28,7 @@
   <section id="buttons">
     <h2>🔘 Buttons</h2>
     <div class="section-note">
-      <strong>Buttons behaviors:</strong> Button behaviors: Variants, sizes, and interactive effects like ripple and
+      <strong>Buttons behaviors:</strong> Variants, sizes, and interactive effects like ripple and
       toast.
     </div>
 
@@ -62,7 +61,7 @@
   <section id="inputs">
     <h2>📝 Inputs</h2>
     <div class="section-note">
-      <strong>Inputs behaviors:</strong> Input behaviors: Auto-enhanced inputs with validation variants, password
+      <strong>Inputs behaviors:</strong> Auto-enhanced inputs with validation variants, password
       toggle, and masking.
     </div>
 
@@ -100,7 +99,7 @@
   <section id="selection">
     <h2>☑️ Selection</h2>
     <div class="section-note">
-      <strong>Selection behaviors:</strong> Selection behaviors: Checkboxes, radios, switches, selects, ratings, and
+      <strong>Selection behaviors:</strong> Checkboxes, radios, switches, selects, ratings, and
       steppers.
     </div>
 
@@ -160,7 +159,7 @@
   <section id="feedback">
     <h2>📢 Feedback</h2>
     <div class="section-note">
-      <strong>Feedback behaviors:</strong> Feedback behaviors: Alerts, badges, progress bars, spinners, and toast
+      <strong>Feedback behaviors:</strong> Alerts, badges, progress bars, spinners, and toast
       notifications.
     </div>
 
@@ -237,7 +236,7 @@
   <section id="overlays">
     <h2>🪟 Overlays</h2>
     <div class="section-note">
-      <strong>Overlays behaviors:</strong> Overlay behaviors: Modals, drawers, tooltips, popovers, confirm dialogs, and
+      <strong>Overlays behaviors:</strong> Modals, drawers, tooltips, popovers, confirm dialogs, and
       lightboxes.
     </div>
 
@@ -292,7 +291,7 @@
   <section id="navigation">
     <h2>🧭 Navigation</h2>
     <div class="section-note">
-      <strong>Navigation behaviors:</strong> Navigation behaviors: Tabs, accordion, breadcrumbs, pagination, and step
+      <strong>Navigation behaviors:</strong> Tabs, accordion, breadcrumbs, pagination, and step
       wizards.
     </div>
 
@@ -347,7 +346,7 @@
   <section id="data">
     <h2>📊 Data</h2>
     <div class="section-note">
-      <strong>Data behaviors:</strong> Data behaviors: Avatars, skeletons, timelines, and keyboard keys.
+      <strong>Data behaviors:</strong> Avatars, skeletons, timelines, and keyboard keys.
     </div>
 
     <h3>Avatars</h3>
@@ -385,7 +384,7 @@
   <section id="media">
     <h2>🖼️ Media</h2>
     <div class="section-note">
-      <strong>Media behaviors:</strong> Media behaviors: Images with lazy loading, galleries, YouTube embeds, and audio
+      <strong>Media behaviors:</strong> Images with lazy loading, galleries, YouTube embeds, and audio
       players.
     </div>
 
@@ -424,7 +423,7 @@
   <section id="effects">
     <h2>✨ Effects</h2>
     <div class="section-note">
-      <strong>Effects behaviors:</strong> Effect behaviors: Attention seekers, entrance animations, particle effects,
+      <strong>Effects behaviors:</strong> Attention seekers, entrance animations, particle effects,
       and ripples.
     </div>
 
@@ -469,7 +468,7 @@
   <section id="utilities">
     <h2>🔧 Utilities</h2>
     <div class="section-note">
-      <strong>Utilities behaviors:</strong> Utility behaviors: Copy, share, print, fullscreen, clock, countdown, and
+      <strong>Utilities behaviors:</strong> Copy, share, print, fullscreen, clock, countdown, and
       dark mode toggle.
     </div>
 


### PR DESCRIPTION
Closes #155. Each section description had a duplicated 'X behaviors:' phrase (removed 10). The page also embedded its own <wb-themecontrol> that overlapped the section heading and duplicated the shell's theme selector; removed it.