### PR TITLE
fix #150: convert legacy data-wb schema examples to v3 bare attributes

### DIFF
--- a/docs/card.md
+++ b/docs/card.md
@@ -64,7 +64,7 @@ When using `<article>` or `<section>`, the component will automatically enhance 
 
 ## Usage Example
 ```html
-<wb-card data-variant="primary" data-hoverable data-clickable>
+<wb-card variant="primary" hoverable clickable>
   <h3>Card Title</h3>
   <p>Card content goes here.</p>
 </wb-card>
@@ -73,9 +73,9 @@ When using `<article>` or `<section>`, the component will automatically enhance 
 > **Developer Tip:** In VS Code, type `<wb-card` to trigger IntelliSense and see available attributes.
 
 **Attribute Definitions:**
-- `data-variant="primary"`: Sets the card variant (e.g., primary, secondary, default). If omitted, `wb-card--default` is used.
-- `data-hoverable`: Adds the `wb-card--hoverable` class for hover effects. Omit or set to `false` to disable.
-- `data-clickable`: Adds the `wb-card--clickable` class for click interaction styling.
+- `variant="primary"`: Sets the card variant (e.g., primary, secondary, default). If omitted, `wb-card--default` is used.
+- `hoverable`: Adds the `wb-card--hoverable` class for hover effects. Omit or set to `false` to disable.
+- `clickable`: Adds the `wb-card--clickable` class for click interaction styling.
 
 ---
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3,6 +3,17 @@
   "description": "WB Starter documentation and guides",
   "categories": [
     {
+      "name": "Guides",
+      "icon": "📘",
+      "docs": [
+        {
+          "file": "V3-GUIDE.md",
+          "title": "wb-starter v3 — Complete Guide",
+          "description": "How to use wb-starter and how it works internally"
+        }
+      ]
+    },
+    {
       "name": "Claude Documentation",
       "icon": "🤖",
       "docs": [

--- a/src/wb-models/button.schema.json
+++ b/src/wb-models/button.schema.json
@@ -309,7 +309,7 @@
       "buttons": [
         {
           "name": "Basic Click",
-          "setup": "<button data-wb='button'>Click Me</button>",
+          "setup": "<wb-button>Click Me</wb-button>",
           "selector": "element",
           "expect": {
             "textContains": "Click Me",
@@ -318,7 +318,7 @@
         },
         {
           "name": "Variant Classes",
-          "setup": "<button data-wb='button' data-wb-variant='primary'>Primary</button>",
+          "setup": "<wb-button variant='primary'>Primary</wb-button>",
           "selector": "element",
           "expect": {
             "hasClass": "wb-button--primary"
@@ -328,7 +328,7 @@
       "focus": [
         {
           "name": "Focus State",
-          "setup": "<button data-wb='button'>Focus Me</button>",
+          "setup": "<wb-button>Focus Me</wb-button>",
           "action": "click",
           "selector": "element",
           "expect": {
@@ -339,7 +339,7 @@
       "disabled": [
         {
           "name": "Disabled State",
-          "setup": "<button data-wb='button' disabled>Disabled</button>",
+          "setup": "<wb-button disabled>Disabled</wb-button>",
           "action": "click",
           "selector": "element",
           "expect": {
@@ -353,7 +353,7 @@
       "keyboard": [
         {
           "name": "Enter Key",
-          "setup": "<button data-wb='button'>Enter Me</button>",
+          "setup": "<wb-button>Enter Me</wb-button>",
           "key": "Enter",
           "expect": {
             "event": "click"
@@ -361,7 +361,7 @@
         },
         {
           "name": "Space Key",
-          "setup": "<button data-wb='button'>Space Me</button>",
+          "setup": "<wb-button>Space Me</wb-button>",
           "key": "Space",
           "expect": {
             "event": "click"

--- a/src/wb-models/card.schema.json
+++ b/src/wb-models/card.schema.json
@@ -159,7 +159,7 @@
       "visual": [
         {
           "name": "Basic Card",
-          "setup": "<article data-wb='card'>Content</article>",
+          "setup": "<wb-card>Content</wb-card>",
           "expect": {
             "visible": true,
             "hasClass": "wb-card"
@@ -167,7 +167,7 @@
         },
         {
           "name": "Card with Header/Footer",
-          "setup": "<article data-wb='card' data-wb-title='Title' data-wb-footer='Footer'>Content</article>",
+          "setup": "<wb-card title='Title' footer='Footer'>Content</wb-card>",
           "expect": {
             "textContains": "Title"
           },
@@ -187,7 +187,7 @@
       "interactions": [
         {
           "name": "Clickable Card",
-          "setup": "<article data-wb='card' data-wb-clickable='true'>Click Me</article>",
+          "setup": "<wb-card clickable>Click Me</wb-card>",
           "action": "click",
           "expect": {
             "event": "click",

--- a/tests/compliance/schema-validation.spec.ts
+++ b/tests/compliance/schema-validation.spec.ts
@@ -369,6 +369,29 @@ test.describe('Schema Validation: Test Section Completeness', () => {
     
     expect(issues, `Invalid setup examples:\n${issues.join('\n')}`).toEqual([]);
   });
+
+  // v3 standard is plain attributes; legacy data-wb / data-wb-* in any
+  // setup example (top-level or per-test) is rejected by strict mode (#150).
+  test('setup examples use v3 bare attributes (no legacy data-wb)', () => {
+    const schemas = getComponentSchemas();
+    const offenders: string[] = [];
+    const walk = (node: any, file: string): void => {
+      if (node === null || typeof node !== 'object') return;
+      for (const [key, val] of Object.entries(node)) {
+        if (key === 'setup') {
+          const items = Array.isArray(val) ? val : [val];
+          for (const item of items) {
+            if (typeof item === 'string' && /data-wb[-=]/.test(item)) {
+              offenders.push(`${file}: ${item}`);
+            }
+          }
+        }
+        walk(val, file);
+      }
+    };
+    for (const [file, schema] of schemas) walk(schema, file);
+    expect(offenders, `Legacy data-wb in setup examples (v3 = bare attrs):\n${offenders.join('\n')}`).toEqual([]);
+  });
   
   test('setup examples reference correct behavior', () => {
     const schemas = getComponentSchemas();


### PR DESCRIPTION
Closes #150. Also fixes the docs-manifest part of #59 (V3-GUIDE.md was unregistered).

## What
- **button.schema.json / card.schema.json** — 9 per-test `setup` examples used legacy `<button data-wb='button'>` / `<article data-wb='card' data-wb-title=…>` forms that strict mode rejects (#143). Converted to `<wb-button>` / `<wb-card>` with bare `variant`/`title`/`footer`/`clickable` attributes.
- **docs/card.md** — usage example + attribute definitions now show the bare `variant`/`hoverable`/`clickable` form (matching `home.html`), not `data-*`.
- **schema-validation.spec.ts** — new compliance test recursively scans every `setup` example (top-level and per-test) and fails on any legacy `data-wb` — guards against regressions.
- **docs/manifest.json** — register `V3-GUIDE.md` under a new "Guides" category (was missing → docs-manifest-integrity failure).

## Verification
- `--project=compliance`: 2442 passed (the new compliance test included); the two prior failures (`docs-manifest-integrity`, `dark-mode-fallbacks`) now pass — manifest fixed, dark-mode was a flake.
- Behavior `data-*` (message/items/type/tab-title) intentionally left untouched — those are canonical for behaviors. Standards/migration docs that intentionally contrast the legacy form were not rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)