### PR TITLE
batch/002 (#4): wizard sibling fix, workflow hardening, missing npm script

### DIFF
--- a/.github/workflows/label-open-prs.yml
+++ b/.github/workflows/label-open-prs.yml
@@ -46,14 +46,18 @@ jobs:
 
       - name: Check and label PRs (limited)
         uses: actions/github-script@v6
+        env:
+          PR_LIST: ${{ steps.prs.outputs.result }}
         with:
           script: |
-            const raw = '${{ steps.prs.outputs.result }}';
-            const prs = JSON.parse(raw || '[]');
+            const prs = JSON.parse(process.env.PR_LIST || '[]');
             const maxRun = Math.min(prs.length, 10);
             let labeled = 0;
             for (const pr of prs.slice(0, maxRun)) {
-              if (!pr.headSha) { continue; }
+              if (!pr || !pr.headSha) {
+                core.warning(`Skipping malformed PR entry: ${JSON.stringify(pr)}`);
+                continue;
+              }
               // Inspect check-runs for the PR head
               const checks = await github.rest.checks.listForRef({
                 owner: context.repo.owner,

--- a/demos/wizard/main.js
+++ b/demos/wizard/main.js
@@ -219,20 +219,7 @@ picker.addEventListener('change', function() {
   buildEditors(state.currentSchema);
 
   var html = buildHtmlString(state.currentSchema.tag, state.currentAttrs);
-  if (state.previewStack.length === 0 || state.containerIndex >= 0) {
-    addToPreviewStack(html, state.currentSchema.tag, Object.assign({}, state.currentAttrs));
-  } else {
-    state.containerIndex = -1;
-    state.previewStack = [{
-      html: html,
-      tag: state.currentSchema.tag,
-      attrs: Object.assign({}, state.currentAttrs),
-      children: []
-    }];
-    state.selectedStackIdx = 0;
-    state.selectedChildIdx = -1;
-    if (isContainerTag(state.currentSchema.tag)) state.containerIndex = 0;
-  }
+  addToPreviewStack(html, state.currentSchema.tag, Object.assign({}, state.currentAttrs));
 
   updateContainerModeUI();
   renderStackList();

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "check:stale-locks": "node scripts/check-stale-locks.js",
     "check:staged-integrity": "node scripts/check-staged-integrity.js",
     "check:critical-scripts": "node scripts/ensure-critical-scripts.js",
+    "check:today-updated": "node scripts/verify-today-mentions.js",
     "cleanup:artifacts": "node scripts/cleanup-artifacts.js",
     "ci:docs-safety": "npm run lint:md-powershell && npm run check:stale-locks && npm run check:critical-scripts",
     "pw:maybe": "node scripts/playwright-if-tests.js --",

--- a/tests/pages/wizard.spec.ts
+++ b/tests/pages/wizard.spec.ts
@@ -282,6 +282,65 @@ test.describe('Wizard - Container Nesting', () => {
 });
 
 // ═══════════════════════════════════════════════════════════════════════════
+// 4b. BUILD TAB - SIBLING INSERTION (BUG FIX: stack nesting)
+// ═══════════════════════════════════════════════════════════════════════════
+
+test.describe('Wizard - Sibling Insertion After Exiting Container', () => {
+  test.beforeEach(async ({ page }) => {
+    await waitForWizardReady(page);
+    // Reset wizard state to ensure clean slate
+    await page.click('#resetWizardBtn');
+    await page.waitForTimeout(200);
+  });
+
+  test('item added after exiting container mode is a sibling, not a child', async ({ page }) => {
+    // Add Demo container — auto-enters container mode
+    await selectComponent(page, 'Demo');
+    const ciEntered = await page.evaluate(() => (window as any).containerIndex);
+    expect(ciEntered).toBe(0);
+
+    // Exit container mode (click the "Exit Container" button in the banner)
+    await page.click('#containerBanner button');
+    await page.waitForTimeout(200);
+
+    const ciExited = await page.evaluate(() => (window as any).containerIndex);
+    expect(ciExited).toBe(-1);
+
+    // Add Audio — must be appended as a sibling of Demo, not inside it
+    await selectComponent(page, 'Audio');
+
+    const stack = await getPreviewStack(page);
+    expect(stack.length).toBe(2);
+    expect(stack[0].tag).toBe('wb-demo');
+    expect(stack[0].children.length).toBe(0);
+    expect(stack[1].tag).toBe('wb-audio');
+  });
+
+  test('multiple siblings accumulate at root when not in container mode', async ({ page }) => {
+    // Add first item (not a container)
+    await selectComponent(page, 'badge');
+    await selectComponent(page, 'Audio');
+
+    const stack = await getPreviewStack(page);
+    // Both items should be at root level as siblings
+    expect(stack.length).toBe(2);
+    expect(stack[0].tag).toBe('wb-badge');
+    expect(stack[1].tag).toBe('wb-audio');
+  });
+
+  test('code sample shows both sibling tags after exit-and-add', async ({ page }) => {
+    await selectComponent(page, 'Demo');
+    await page.click('#containerBanner button');
+    await page.waitForTimeout(200);
+    await selectComponent(page, 'Audio');
+
+    const html = await getCodeSample(page);
+    expect(html).toContain('<wb-demo');
+    expect(html).toContain('<wb-audio');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════
 // 5. PREVIEW TAB - IFRAME RENDERING
 // ═══════════════════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
Part of #4 (mass-merge backlog). Re-lands three stragglers from stale/conflicting Copilot drafts onto current `main`, each verified fresh.

## Changes
- **demos/wizard/main.js** (supersedes #111) — selecting a component while the preview stack was non-empty and not in container mode **wiped the stack** instead of appending a sibling. Now always `addToPreviewStack()`. +3 regression tests in `wizard.spec.ts`.
- **.github/workflows/label-open-prs.yml** (supersedes #113) — pass the PR list via an env var instead of inline `${{ }}` interpolation (double-serialization / quote breakage) + warn-and-skip malformed entries.
- **package.json** (the real piece of #109) — add `check:today-updated` → `verify-today-mentions.js`. The `check-today-updated.yml` workflow already calls `npm run check:today-updated`, but the script was missing, so that CI job was broken.

## Verification
- `tests/pages/wizard.spec.ts`: **50 passed** (incl. the 3 new sibling-insertion tests).
- `--project=compliance`: **2444 passed, 0 failed**.
- `npm run check:today-updated` resolves (exit 0).

Note: pre-existing `regression`/`base` failures on `main` are unrelated to this batch (proven on clean `origin/main`); tracked separately in #159 and a card bare-attribute fix to follow.

Closes #111, #113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)