### PR TITLE
fix(card): read bare subtitle/footer attributes (#150 follow-up)

### DIFF
--- a/src/wb-viewmodels/card.js
+++ b/src/wb-viewmodels/card.js
@@ -89,9 +89,9 @@ export function cardBase(element, options = {}) {
     ...options, // Spread first to allow overrides, but specific logic below takes precedence
     behavior: options.behavior || 'card',
     title: options.title || element.dataset.title || element.getAttribute('title') || '',
-    subtitle: options.subtitle || element.dataset.subtitle || '',
+    subtitle: options.subtitle || element.dataset.subtitle || element.getAttribute('subtitle') || '',
     content: options.content || element.dataset.content || element.getAttribute('content') || '',
-    footer: options.footer || element.dataset.footer || '',
+    footer: options.footer || element.dataset.footer || element.getAttribute('footer') || '',
     variant: options.variant || element.dataset.variant || element.getAttribute('variant') || 'default',
     badge: options.badge || element.dataset.badge || element.getAttribute('badge') || '',
     clickable: parseBoolean(options.clickable) ?? (element.dataset.clickable === 'true' || (element.hasAttribute('data-clickable') && element.dataset.clickable !== 'false') || element.hasAttribute('clickable')),


### PR DESCRIPTION
`card.js` read `title`/`content`/`variant`/`badge` from the bare attribute but `subtitle`/`footer` only from `options`/`dataset`, so `<wb-card subtitle="…" footer="…">` rendered neither — contradicting the v3 bare-attribute standard and the card.md docs from #150.

## Fix
Add the `getAttribute('subtitle')`/`getAttribute('footer')` fallback to match the sibling props (2-line change).

## Verification
- `tests/cards/card.spec.ts` (base project): was 13/15 with subtitle+footer failing → now **15/15**.

Fixes the 2 pre-existing `base`-project failures surfaced by `npm test`. The remaining 4 `regression` failures are a separate, deeper auto-injection issue tracked in #159 (core-runtime semantics; not bundled here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)