### PR TITLE
fix #159: article→card semantic hijack + mdhtml path resolution (regression green)

### DIFF
--- a/src/core/wb.js
+++ b/src/core/wb.js
@@ -430,6 +430,15 @@ const WB = {
           const htmlEl = /** @type {HTMLElement} */ (element);
           // Only skip if explicitly ignored
           if (!htmlEl.hasAttribute('x-ignore')) {
+            // A semantic <article> auto-injects as a card and claims its own
+            // <header>/<footer> (rendered as wb-card__header / wb-card__footer).
+            // Don't let the generic header/footer behaviors hijack a header or
+            // footer that lives inside an <article>/.wb-card — that produced a
+            // racing wb-header instead of wb-card__header. (#159)
+            if ((behavior === 'header' || behavior === 'footer') &&
+                htmlEl.parentElement && htmlEl.parentElement.closest('article, .wb-card')) {
+              return;
+            }
             // We don't check for other attributes here anymore.
             // Auto-inject is additive.
             WB.inject(htmlEl, behavior);

--- a/src/wb-viewmodels/card.js
+++ b/src/wb-viewmodels/card.js
@@ -385,8 +385,9 @@ export function cardBase(element, options = {}) {
       // MVVM: Do NOT wipe innerHTML. We enhance what's there.
       // element.innerHTML = '';
       
-      // HEADER - Always show if title or subtitle exists
-      if (showHeader && (config.title || config.subtitle || headerContent || config.badge)) {
+      // HEADER - show if title/subtitle/badge config exists OR a semantic
+      // <header> is already present (enhance it to wb-card__header). (#159)
+      if (showHeader && (header || config.title || config.subtitle || headerContent || config.badge)) {
         if (!header) {
           const headerEl = document.createElement('header');
           headerEl.className = 'wb-card__header';
@@ -489,8 +490,9 @@ export function cardBase(element, options = {}) {
         }
       }
       
-      // FOOTER - Show if footer text exists
-      if (showFooter && (config.footer || footerContent)) {
+      // FOOTER - show if footer config text exists OR a semantic <footer> is
+      // already present (enhance it to wb-card__footer). (#159)
+      if (showFooter && (footer || config.footer || footerContent)) {
         if (!footer) {
           const footerEl = document.createElement('footer');
           footerEl.className = 'wb-card__footer';

--- a/src/wb-viewmodels/mdhtml.js
+++ b/src/wb-viewmodels/mdhtml.js
@@ -104,14 +104,16 @@ export async function mdhtml(element, options = {}) {
         // If it's an HTTP URL, use as-is
         if (fetchPath.startsWith('http://') || fetchPath.startsWith('https://')) {
           // Use as-is
+        } else if (window.location.protocol === 'blob:' || window.location.protocol === 'data:') {
+          // In blob: or data: contexts relative paths can't resolve — pin to the dev origin
+          if (!fetchPath.startsWith('/')) { fetchPath = '/' + fetchPath; }
+          fetchPath = 'http://localhost:3000' + fetchPath;
         } else {
-          if (!fetchPath.startsWith('/')) {
-            fetchPath = '/' + fetchPath;
-          }
-          // In blob: or data: contexts, relative paths won't resolve — use absolute URL
-          if (window.location.protocol === 'blob:' || window.location.protocol === 'data:') {
-            fetchPath = 'http://localhost:3000' + fetchPath;
-          }
+          // Resolve relative to the current page using standard URL semantics so
+          // an article in /articles/ can reference a sibling .md (src="x.md")
+          // without it being forced to site root. Absolute "/docs/x.md" paths are
+          // preserved unchanged. (#159 — article-code)
+          fetchPath = new URL(fetchPath, window.location.href).pathname;
         }
         
         // Log for debugging

--- a/tests/regression/article-code.spec.ts
+++ b/tests/regression/article-code.spec.ts
@@ -11,9 +11,10 @@ test.describe('External Markdown Code Block Injection', () => {
     // Assuming Playwright's baseURL is set to the root, or we use a relative path
     await page.goto('/articles/resilience-through-separation.html');
 
-    // Wait for the wb-mdhtml component to load
-    // It adds the class 'wb-mdhtml--loaded' when done
-    const mdhtml = page.locator('wb-mdhtml');
+    // Wait for the wb-mdhtml component to load. The page has two <wb-mdhtml>
+    // elements (code + decoupled); target the code one explicitly to avoid a
+    // strict-mode ambiguity. It adds the class 'wb-mdhtml--loaded' when done.
+    const mdhtml = page.locator('wb-mdhtml[src="resilience-through-separation-code.md"]');
     await expect(mdhtml).toHaveClass(/wb-mdhtml--loaded/, { timeout: 10000 });
 
     // Verify content text exists in the DOM
@@ -22,10 +23,10 @@ test.describe('External Markdown Code Block Injection', () => {
 
     // Verify some formatting elements (e.g. Highlight.js classes or standard code blocks)
     // wb-mdhtml uses 'marked' which outputs <pre><code>...</code></pre>
-    const pre = mdhtml.locator('pre');
+    const pre = mdhtml.locator('pre').first();
     await expect(pre).toBeVisible();
 
-    const code = pre.locator('code');
+    const code = pre.locator('code').first();
     await expect(code).toBeVisible();
     
     // Check if it's the expected language

--- a/tests/repro_explicit_card.html
+++ b/tests/repro_explicit_card.html
@@ -6,7 +6,9 @@
     <title>Explicit Card Test</title>
     <script type="module">
         import WB from '../src/core/wb.js';
-        WB.init({ debug: true, autoInject: true });
+        // This page verifies the NON-auto-inject path: a plain <article> stays
+        // plain, while an explicit <wb-card> custom tag still upgrades.
+        WB.init({ debug: true, autoInject: false });
     </script>
 </head>
 

--- a/tests/repro_optout.html
+++ b/tests/repro_optout.html
@@ -14,11 +14,11 @@
         <header><h3>Auto</h3></header>
     </article>
 
-    <!-- Should NOT be a card -->
-    <article id="optout">
+    <!-- Should NOT be a card (canonical v3 opt-out: x-ignore) -->
+    <article id="optout" x-ignore>
         <header><h3>Opt-out</h3></header>
     </article>
-    
+
     <!-- Should NOT be a card -->
     <article id="optout-ignore" x-ignore>
         <header><h3>Ignore Attribute</h3></header>


### PR DESCRIPTION
Closes #159. Fixes all 4 regression-project failures surfaced by `npm test` (the card cluster + the mdhtml article-code test). These were pre-existing on `main`; none came from batch/002/003.

## Runtime fixes
- **`src/core/wb.js`** — under autoInject, a native `<header>`/`<footer>` inside an `<article>`/`.wb-card` was injected with the generic header/footer behavior (`wb-header`), racing the card's own enhancement. Skip those behaviors inside a card; the card claims them.
- **`src/wb-viewmodels/card.js`** — the header/footer enhancement block was gated on title/subtitle/badge/footer *config*, so a semantic `<article>` whose title lives in `<header><h3>` never got `wb-card__header`/`wb-card__footer`. Also enter the block when an existing semantic `<header>`/`<footer>` is present.
- **`src/wb-viewmodels/mdhtml.js`** — relative `src` was forced to site root (`'/' + path`), so `/articles/foo.html` with `src="foo-code.md"` fetched `/foo-code.md` (404). Use standard `new URL(src, location.href)` resolution; absolute `/docs/x.md` preserved, blob:/data: still pinned to dev origin.

## Fixture/test corrections
- **`tests/repro_explicit_card.html`** — set `autoInject:false` (the fixture contradicted its own test name "should NOT be auto-injected").
- **`tests/repro_optout.html`** — `#optout` had no opt-out marker; use canonical v3 `x-ignore`.
- **`tests/regression/article-code.spec.ts`** — page has two `<wb-mdhtml>`; scope to the code one (was a strict-mode ambiguity) + `.first()` on pre/code.

## Verification
- `--project=regression`: **9 passed, 0 failed** (was 4 failed).
- `--project=compliance --project=base --project=behaviors` at the card-fix commit: **3630 passed, 0 failed** (4 pre-existing timing flakes, none card-related).
- article-code stable 3/3; all mdhtml/doc-viewer/schema-viewer specs 190 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)