### PR TITLE
fix: docs links to missing files + a real test (#125/#140 redux)

### DIFF
--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -284,11 +284,6 @@
           "description": "Documentation for Card Overview"
         },
         {
-          "file": "components/cards/index.md",
-          "title": "cards Index",
-          "description": "Documentation for cards Index"
-        },
-        {
           "file": "components/cards/README.md",
           "title": "cards Readme",
           "description": "Documentation for cards Readme"
@@ -309,19 +304,9 @@
           "description": "Documentation for Drawer"
         },
         {
-          "file": "components/feedback/README.md",
-          "title": "feedback Readme",
-          "description": "Documentation for feedback Readme"
-        },
-        {
           "file": "components/feedback/feedback.readme.md",
           "title": "Feedback Components README",
           "description": "Feedback component overview"
-        },
-        {
-          "file": "components/forms/README.md",
-          "title": "forms Readme",
-          "description": "Documentation for forms Readme"
         },
         {
           "file": "components/forms/forms.readme.md",
@@ -329,19 +314,9 @@
           "description": "Form component overview"
         },
         {
-          "file": "components/layout/README.md",
-          "title": "layout Readme",
-          "description": "Documentation for layout Readme"
-        },
-        {
           "file": "components/layout/layout.readme.md",
           "title": "Layout Components README",
           "description": "Layout component overview"
-        },
-        {
-          "file": "components/navigation/README.md",
-          "title": "navigation Readme",
-          "description": "Documentation for navigation Readme"
         },
         {
           "file": "components/navigation/navigation.readme.md",
@@ -352,11 +327,6 @@
           "file": "components/README.md",
           "title": "components Readme",
           "description": "Documentation for components Readme"
-        },
-        {
-          "file": "components/components.readme.md",
-          "title": "Components README",
-          "description": "All components overview"
         },
         {
           "file": "components/demo/demo.md",
@@ -390,11 +360,6 @@
           "description": "Theme system and customization"
         },
         {
-          "file": "css-standards.md",
-          "title": "CSS Standards",
-          "description": "CSS coding standards"
-        },
-        {
           "file": "code-examples-standard.md",
           "title": "Code Examples Standard",
           "description": "Formatting rules for code examples"
@@ -414,11 +379,6 @@
           "file": "test-schema-standard.md",
           "title": "Schema Testing",
           "description": "Schema-based testing approach"
-        },
-        {
-          "file": "builder-testing.md",
-          "title": "Builder Testing",
-          "description": "Testing the page builder"
         },
         {
           "file": "schemaTestValue.md",
@@ -488,16 +448,6 @@
           "description": "Planned improvements"
         },
         {
-          "file": "USER-PAGE-BUILDER-PLAN.md",
-          "title": "Page Builder Plan",
-          "description": "Builder roadmap"
-        },
-        {
-          "file": "builder.todo.md",
-          "title": "Builder TODO",
-          "description": "Builder task list"
-        },
-        {
           "file": "semantic-audit.md",
           "title": "Semantic Audit",
           "description": "HTML audit results"
@@ -508,41 +458,6 @@
           "description": "Documentation for X USAGE AUDIT"
         },
         {
-          "file": "builder/BUILDER-FIXES.md",
-          "title": "BUILDER FIXES",
-          "description": "Documentation for BUILDER FIXES"
-        },
-        {
-          "file": "builder-interaction-rules.md",
-          "title": "Builder Interaction Rules",
-          "description": "Documentation for Builder Interaction Rules"
-        },
-        {
-          "file": "builder-properties.md",
-          "title": "Builder Properties",
-          "description": "Documentation for Builder Properties"
-        },
-        {
-          "file": "builder-section-focus.md",
-          "title": "Builder Section Focus",
-          "description": "Documentation for Builder Section Focus"
-        },
-        {
-          "file": "builder/builder-tree.md",
-          "title": "Builder Tree",
-          "description": "Documentation for Builder Tree"
-        },
-        {
-          "file": "builder/pages.md",
-          "title": "Builder Pages",
-          "description": "Builder page management"
-        },
-        {
-          "file": "PAGE-BUILDER-RULES.md",
-          "title": "Page Builder Rules",
-          "description": "Content creation rules for WB Page Builder"
-        },
-        {
           "file": "MVVM-MIGRATION-PLAN.md",
           "title": "MVVM MIGRATION PLAN",
           "description": "Documentation for MVVM MIGRATION PLAN"
@@ -551,17 +466,6 @@
           "file": "MVVM-MIGRATION.md",
           "title": "MVVM MIGRATION",
           "description": "Documentation for MVVM MIGRATION"
-        }
-      ]
-    },
-    {
-      "name": "Research",
-      "icon": "📑",
-      "pages": [
-        {
-          "page": "schema-first-architecture",
-          "title": "Schema-First Architecture",
-          "description": "Research paper on AI error elimination"
         }
       ]
     },
@@ -640,16 +544,6 @@
           "file": "components/semantic/figure.md",
           "title": "Figure",
           "description": "Documentation for Figure"
-        },
-        {
-          "file": "components/semantic/index.md",
-          "title": "semantic Index",
-          "description": "Documentation for semantic Index"
-        },
-        {
-          "file": "components/semantic/README.md",
-          "title": "semantic Readme",
-          "description": "Documentation for semantic Readme"
         },
         {
           "file": "components/semantic/time.md",
@@ -788,11 +682,6 @@
           "description": "Documentation for the home page layout"
         },
         {
-          "file": "DATA-FILES.md",
-          "title": "DATA-FILES",
-          "description": "Documentation for DATA-FILES"
-        },
-        {
           "file": "performance.md",
           "title": "Performance",
           "description": "Documentation for Performance"
@@ -816,31 +705,6 @@
           "file": "templates.md",
           "title": "Templates",
           "description": "Documentation for Templates"
-        },
-        {
-          "file": "deploying-wb-starter-to-render.md",
-          "title": "Deploying-wb-starter-to-render",
-          "description": "Documentation for Deploying-wb-starter-to-render"
-        },
-        {
-          "file": "builder-onboarding-flow.md",
-          "title": "Builder-onboarding-flow",
-          "description": "Documentation for Builder-onboarding-flow"
-        },
-        {
-          "file": "builder-workflow.md",
-          "title": "Builder-workflow",
-          "description": "Documentation for Builder-workflow"
-        },
-        {
-          "file": "architecture/ATTRIBUTE-NAMING-STANDARD.md",
-          "title": "ATTRIBUTE-NAMING-STANDARD",
-          "description": "Documentation for ATTRIBUTE-NAMING-STANDARD"
-        },
-        {
-          "file": "architecture/WBPARTS.md",
-          "title": "WBPARTS",
-          "description": "Documentation for WBPARTS"
         },
         {
           "file": "schema-first-architecture.md",
@@ -911,11 +775,6 @@
           "file": "architecture/standards/SCHEMA-SPECIFICATION.md",
           "title": "Schema Specification",
           "description": "Detailed schema specification standard"
-        },
-        {
-          "file": "architecture.md",
-          "title": "Architecture Overview",
-          "description": "High-level architecture documentation"
         },
         {
           "file": "claude/SCHEMAS-GUIDE.md",

--- a/server.js
+++ b/server.js
@@ -558,6 +558,18 @@ app.use((req, res, next) => {
     return res.status(404).send(`File not found: ${req.path}`);
   }
 
+  // Explicit .html file requests must point at a real file. Falling back to the
+  // SPA shell (index.html) for a MISSING .html masked broken links — they
+  // returned 200 with the home page instead of 404, so neither users nor tests
+  // could tell the page didn't exist. (#125 follow-up)
+  if (ext === '.html') {
+    const filePath = path.join(rootDir, req.path);
+    if (fs.existsSync(filePath)) {
+      return res.sendFile(filePath);
+    }
+    return res.status(404).send(`File not found: ${req.path}`);
+  }
+
   res.sendFile(path.join(rootDir, 'index.html'));
 });
 

--- a/tests/behaviors/docs-links.spec.ts
+++ b/tests/behaviors/docs-links.spec.ts
@@ -1,32 +1,60 @@
 /**
- * Docs page links resolve (issue #125)
- * Doc-viewer links must point at the real /public/doc-viewer.html so they
- * resolve under both `npm start` (server.js) and `npm run dev` (static serve).
+ * Docs page links must resolve to REAL content (issues #125, #140).
+ *
+ * Why the old test was useless: it only asserted `status < 400`. The server's
+ * SPA catch-all serves index.html for ANY unmatched path, so a *missing*
+ * /pages/X.html returned 200 with the home shell. The status check passed while
+ * the link was broken (clicking it opened the home page, not the doc).
+ *
+ * This test compares each link's body against the SPA shell, so a fallback is
+ * detected as the broken link it is.
  */
 import { test, expect } from '@playwright/test';
 
+const ORIGIN = 'http://localhost:3000';
+
 test.describe('docs page links', () => {
-  test('doc cards render and every href resolves (no 404)', async ({ page }) => {
+  test('every docs-card link resolves to real content, not the SPA fallback shell', async ({ page }) => {
     await page.goto('/?page=docs');
     await page.waitForSelector('.docs-card', { timeout: 20000 });
 
     const hrefs = await page.locator('a.docs-card').evaluateAll(
       (els) => els.map((e) => (e as HTMLAnchorElement).getAttribute('href') || '')
     );
-    expect(hrefs.length).toBeGreaterThan(0);
+    expect(hrefs.length, 'docs cards should render').toBeGreaterThan(0);
 
-    // doc-viewer links must use the real /public path (the bug used /doc-viewer.html)
-    const docViewer = hrefs.filter((h) => h.includes('doc-viewer.html'));
-    if (docViewer.length) {
-      for (const h of docViewer) {
-        expect(h, `doc-viewer link should point at /public: ${h}`).toContain('/public/doc-viewer.html');
+    // The home shell that the SPA catch-all returns for missing paths.
+    const shell = (await (await page.request.get('/index.html')).text()).trim();
+    const isShellFallback = (body: string) =>
+      body.trim() === shell || (/data-theme=/.test(body) && /site__loading|new WBSite|WBSite\s*\(/.test(body));
+
+    const broken: string[] = [];
+    for (const href of hrefs) {
+      // doc-viewer links: the doc itself (?file=) is the resource that must exist
+      const target = href.includes('/public/doc-viewer.html')
+        ? new URL(href, ORIGIN).searchParams.get('file') || href
+        : href;
+
+      const resp = await page.request.get(target);
+      const body = await resp.text();
+      if (resp.status() >= 400) {
+        broken.push(`${href} → ${target} returned ${resp.status()}`);
+      } else if (isShellFallback(body)) {
+        broken.push(`${href} → ${target} returned the SPA fallback shell (the target file is missing)`);
       }
     }
 
-    // Every link must resolve (status < 400)
-    for (const h of hrefs) {
-      const resp = await page.request.get(h);
-      expect(resp.status(), `href ${h} returned ${resp.status()}`).toBeLessThan(400);
+    expect(broken, `Broken docs links (resolve to the home shell or 404):\n${broken.join('\n')}`).toEqual([]);
+  });
+
+  test('doc-viewer links use the real /public path (#125)', async ({ page }) => {
+    await page.goto('/?page=docs');
+    await page.waitForSelector('.docs-card', { timeout: 20000 });
+    const docViewer = await page.locator('a.docs-card[href*="doc-viewer"]').evaluateAll(
+      (els) => els.map((e) => (e as HTMLAnchorElement).getAttribute('href') || '')
+    );
+    for (const h of docViewer) {
+      expect(h, `doc-viewer link should point at /public: ${h}`).toContain('/public/doc-viewer.html');
     }
   });
 });


### PR DESCRIPTION
The docs page (?page=docs) catalog linked to 27 files that don't exist — doc-viewer cards whose `.md` 404s ("stuck on loading", #140) and a page-link that the SPA catch-all silently served the home shell for (#125).

**Why CI never caught it:** `docs-links.spec.ts` asserted only `status < 400` on the **doc-viewer.html** URL (always 200), never the actual `?file=` target, and the SPA fallback returns 200 for any missing path.

- **Recreated the test**: now fetches each link's real target and fails on 404 *or* the SPA shell fallback. Reproduced 34 broken links; green after the fix.
- **Fixed the data**: pruned 26 dead doc + 1 dead page entries (+ empty Research category) from `docs/manifest.json`.
- **Fixed the root**: `server.js` now 404s a missing `.html` instead of falling back to `index.html`, so broken links can't masquerade as 200.