### PR TITLE
fix #171: mobile nav backdrop swallowed all content clicks when closed

### DIFF
--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -671,6 +671,10 @@ h5, h6 {
   background: rgba(0, 0, 0, 0.5);
   z-index: 98;
   opacity: 0;
+  /* Closed: invisible AND non-interactive, or this full-screen fixed overlay
+     swallows every click on the page content (#171). Only the OPEN (.visible)
+     backdrop captures taps — so tapping it closes the drawer. */
+  pointer-events: none;
   transition: opacity 0.3s ease;
 }
 
@@ -678,9 +682,10 @@ h5, h6 {
   .site__nav-backdrop {
     display: block;
   }
-  
+
   .site__nav-backdrop.visible {
     opacity: 1;
+    pointer-events: auto;
   }
 }
 

--- a/tests/mobile/backdrop-clickthrough.spec.ts
+++ b/tests/mobile/backdrop-clickthrough.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * #171 — the mobile nav backdrop must not swallow clicks when the drawer is
+ * closed. It's a full-screen position:fixed overlay; with only opacity:0 (no
+ * pointer-events:none) it intercepted every click on the page content, so no
+ * link/card/button responded to taps on phones.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('Mobile nav backdrop click-through (#171)', () => {
+  test('closed drawer: backdrop does not intercept clicks over page content', async ({ page }) => {
+    await page.goto('http://localhost:3000/?page=docs');
+    await page.waitForSelector('a.docs-card', { timeout: 20000 });
+    await page.waitForTimeout(800);
+
+    const r = await page.evaluate(() => {
+      const card = document.querySelector('a.docs-card') as HTMLElement;
+      const box = card.getBoundingClientRect();
+      const hit = document.elementFromPoint(box.left + box.width / 2, box.top + box.height / 2);
+      const backdrop = document.querySelector('.site__nav-backdrop');
+      return {
+        backdropPointerEvents: backdrop ? getComputedStyle(backdrop).pointerEvents : 'none',
+        hitIsCard: !!hit && (card.contains(hit) || hit === card),
+        hitClass: hit ? (hit.className || hit.tagName).toString().slice(0, 40) : 'none',
+      };
+    });
+
+    expect(r.backdropPointerEvents, 'closed backdrop must have pointer-events:none').toBe('none');
+    expect(r.hitIsCard, `the element under a docs card is "${r.hitClass}", not the card — clicks are blocked`).toBe(true);
+  });
+
+  test('a real tap on a content link is not swallowed by the backdrop', async ({ page, context }) => {
+    await page.goto('http://localhost:3000/?page=docs');
+    await page.waitForSelector('a.docs-card', { timeout: 20000 });
+    await page.waitForTimeout(800);
+    // doc-viewer cards open in a new tab; a real click must produce that popup.
+    const popupP = context.waitForEvent('page', { timeout: 8000 }).catch(() => null);
+    await page.locator('a.docs-card').first().click(); // real pointer click, no force
+    const popup = await popupP;
+    expect(popup, 'clicking a docs card should open the doc-viewer (not be eaten by the backdrop)').not.toBeNull();
+    await popup?.close();
+  });
+});


### PR DESCRIPTION
Closes #171. The closed `.site__nav-backdrop` (full-screen fixed overlay, only toggled by opacity) had default pointer-events, so it intercepted every tap on page content — no link/card/button responded on phones (the real cause of "none of the docs cards react to a click"). Fix: `pointer-events:none` closed, `auto` only when `.visible`. Test: `tests/mobile/backdrop-clickthrough.spec.ts` (reproduced the bug, 4/4 green after).