### PR TITLE
fix #173/#174: button variants render + wb-demo navigation crash

### DIFF
--- a/src/styles/behaviors/button.css
+++ b/src/styles/behaviors/button.css
@@ -148,3 +148,19 @@ button-tooltip[disabled] {
   cursor: not-allowed;
   pointer-events: none;
 }
+
+/* #173 — the showcase + ~60 usages use the .wb-btn / .wb-btn--* prefix while the
+   rules above use .wb-button. Compound .wb-btn.wb-btn--* selectors (specificity
+   0,2,0) so they beat any plain base .wb-btn rule regardless of load order. */
+.wb-btn.wb-btn--primary   { background-color: var(--primary); color:#fff; border-color: transparent; }
+.wb-btn.wb-btn--primary:hover   { background-color: var(--primary-dark); }
+.wb-btn.wb-btn--secondary { background-color: var(--secondary); color:#fff; border-color: transparent; }
+.wb-btn.wb-btn--secondary:hover { background-color: var(--secondary-dark); }
+.wb-btn.wb-btn--success   { background-color: var(--success-color); color:#fff; border-color: transparent; }
+.wb-btn.wb-btn--danger,
+.wb-btn.wb-btn--error     { background-color: var(--danger-color); color:#fff; border-color: transparent; }
+.wb-btn.wb-btn--warning   { background-color: var(--warning-color); color:#fff; border-color: transparent; }
+.wb-btn.wb-btn--ghost     { background-color: transparent; color: var(--text-primary); border: 1px solid var(--border-color); }
+.wb-btn.wb-btn--ghost:hover{ background-color: var(--bg-tertiary); border-color: var(--text-secondary); }
+.wb-btn.wb-btn--link      { background-color: transparent; color: var(--primary); border: none; box-shadow: none; }
+.wb-btn:disabled { opacity: 0.5; cursor: not-allowed; }

--- a/src/wb-viewmodels/wb-demo.js
+++ b/src/wb-viewmodels/wb-demo.js
@@ -27,7 +27,10 @@ export class WBDemo extends HTMLElement {
   }
 
   disconnectedCallback() {
-    if (this._cleanup) {
+    // _cleanup may hold the Promise from an async WB.inject() (truthy but not
+    // callable) — only invoke it when it's actually a function, or every
+    // navigation throws "this._cleanup is not a function". (#174)
+    if (typeof this._cleanup === 'function') {
       this._cleanup();
     }
   }


### PR DESCRIPTION
Two root causes behind the broadly-regressed behaviors showcase. **wb-demo** threw `this._cleanup is not a function` on every navigation (guard checked truthiness, but _cleanup holds the async WB.inject Promise) — flooded the console; now guarded with typeof. **Buttons** rendered identical because button.css styled `.wb-button--*` while the markup uses `.wb-btn--*`; aliased with `.wb-btn.wb-btn--*` specificity. Both verified in the live preview (console clean; primary blue / secondary green / ghost transparent).