### PR TITLE
fix: WB Behaviors showcase regressions (#176–#184) — alerts, spinners, rating, stepper, cards, nav, hero, code, feature cards

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -25,30 +25,42 @@
 <h2>Features</h2>
 <p>Everything you need to build modern UIs</p>
 <wb-grid>
-  <wb-card variant="float">
-    <h3>🧩 Component Library</h3>
-    <p>Over 40 ready-to-use UI components including Cards, Modals, Drawers, and Navigation.</p>
-  </wb-card>
-  <wb-card variant="float">
-    <h3>⚡ Behaviors System</h3>
-    <p>Compose interactions like Lego bricks. Add x-fade-in, x-sticky, or x-validate to any element.</p>
-  </wb-card>
-  <wb-card variant="float">
-    <h3>🎨 Theme Engine</h3>
-    <p>23 built-in themes with CSS Variable support. Dark mode, Light mode, and Auto detection out of the box.</p>
-  </wb-card>
-  <wb-card variant="float">
-    <h3>📊 Data Viz</h3>
-    <p>Built-in charts, stats cards, and audio visualizations powered by Web Standards.</p>
-  </wb-card>
-  <wb-card variant="float">
-    <h3>♿ Accessible</h3>
-    <p>ARIA attributes and keyboard navigation are baked into every component by default.</p>
-  </wb-card>
-  <wb-card variant="float">
-    <h3>🚀 Performance</h3>
-    <p>Zero-runtime compilation. Browsers are fast now. We let them do their job.</p>
-  </wb-card>
+  <a href="?page=components" class="feature-card-link" aria-label="Explore the Component Library">
+    <wb-card variant="float">
+      <h3>🧩 Component Library</h3>
+      <p>Over 40 ready-to-use UI components including Cards, Modals, Drawers, and Navigation.</p>
+    </wb-card>
+  </a>
+  <a href="?page=behaviors" class="feature-card-link" aria-label="Explore the Behaviors System">
+    <wb-card variant="float">
+      <h3>⚡ Behaviors System</h3>
+      <p>Compose interactions like Lego bricks. Add x-fade-in, x-sticky, or x-validate to any element.</p>
+    </wb-card>
+  </a>
+  <a href="?page=themes" class="feature-card-link" aria-label="Explore the Theme Engine">
+    <wb-card variant="float">
+      <h3>🎨 Theme Engine</h3>
+      <p>23 built-in themes with CSS Variable support. Dark mode, Light mode, and Auto detection out of the box.</p>
+    </wb-card>
+  </a>
+  <a href="?page=demos" class="feature-card-link" aria-label="See Data Viz demos">
+    <wb-card variant="float">
+      <h3>📊 Data Viz</h3>
+      <p>Built-in charts, stats cards, and audio visualizations powered by Web Standards.</p>
+    </wb-card>
+  </a>
+  <a href="?page=docs" class="feature-card-link" aria-label="Read about Accessibility">
+    <wb-card variant="float">
+      <h3>♿ Accessible</h3>
+      <p>ARIA attributes and keyboard navigation are baked into every component by default.</p>
+    </wb-card>
+  </a>
+  <a href="?page=docs" class="feature-card-link" aria-label="Read about Performance">
+    <wb-card variant="float">
+      <h3>🚀 Performance</h3>
+      <p>Zero-runtime compilation. Browsers are fast now. We let them do their job.</p>
+    </wb-card>
+  </a>
 </wb-grid>
 
 <h2>Live Demos</h2>

--- a/src/core/mvvm/schema-builder.js
+++ b/src/core/mvvm/schema-builder.js
@@ -211,6 +211,21 @@ function extractData(element, schema) {
     }
   }
   
+  // Honor property aliases declared in the schema BEFORE defaults are applied,
+  // so an alias attribute beats the default. e.g. the alert schema declares
+  // `variant` with aliases ["type"] so <wb-alert type="success"> works (#176).
+  if (schema.properties) {
+    for (const [propName, propDef] of Object.entries(schema.properties)) {
+      const aliases = propDef && propDef.aliases;
+      if (Array.isArray(aliases) && data[propName] === undefined) {
+        for (const alias of aliases) {
+          const aliasKey = alias.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+          if (data[aliasKey] !== undefined) { data[propName] = data[aliasKey]; break; }
+        }
+      }
+    }
+  }
+
   // Apply defaults from schema
   if (schema.properties) {
     applyDefaults(data, schema.properties);

--- a/src/core/site-engine.js
+++ b/src/core/site-engine.js
@@ -66,6 +66,18 @@ export default class WBSite {
             const page = new URLSearchParams(href).get('page');
             history.pushState(null, '', href);
             this.navigateTo(page);
+          } else if (href && href.length > 1 && href.startsWith('#')) {
+            // In-page anchor (e.g. the behaviors-page section nav). Native anchor
+            // scrolling was unreliable in the SPA — lazy-injected components reflow
+            // the page after the jump, leaving the link looking dead (#181). Drive
+            // the scroll explicitly; scroll-margin-top on the target clears the
+            // sticky header.
+            const target = document.querySelector(href);
+            if (target) {
+              e.preventDefault();
+              target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+              history.replaceState(null, '', href);
+            }
           }
         }
       });

--- a/src/styles/behaviors/card.css
+++ b/src/styles/behaviors/card.css
@@ -130,6 +130,27 @@
   background: var(--bg-elevated);
 }
 
+/* Float — the most-used card variant in the showcase, but it had NO CSS rule, so
+   "float" cards fell back to the flat base and (with --border-color undefined)
+   read as undemarcated blocks (#180). Give it clear elevation + the hairline
+   border so it always reads as a discrete, floating card. */
+.wb-card--float {
+  box-shadow: var(--shadow-float, 0 2px 4px rgba(0,0,0,0.12), 0 8px 24px rgba(0,0,0,0.18));
+  border: 1px solid var(--border-color);
+  background: var(--bg-secondary);
+}
+.wb-card--float:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-float-hover, 0 4px 8px rgba(0,0,0,0.16), 0 12px 32px rgba(0,0,0,0.24));
+}
+
+/* Cosmic — decorative gradient card used in a couple of demos (was undefined). */
+.wb-card--cosmic {
+  border: 1px solid var(--primary);
+  background: linear-gradient(135deg, var(--bg-secondary), var(--primary-dark));
+  box-shadow: 0 0 24px -6px var(--primary);
+}
+
 /* Hoverable */
 .wb-card--hoverable:hover {
   transform: translateY(-2px);

--- a/src/styles/behaviors/stepper.css
+++ b/src/styles/behaviors/stepper.css
@@ -1,0 +1,61 @@
+/**
+ * Stepper Behavior Styles
+ * -----------------------------------------------------------------------------
+ * Works with src/wb-viewmodels/stepper.js — a [−][value][+] numeric control.
+ * Theme-driven only (no hardcoded colors). #178
+ * -----------------------------------------------------------------------------
+ */
+
+.wb-stepper {
+  display: inline-flex;
+  align-items: stretch;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md, 6px);
+  overflow: hidden;
+  background: var(--bg-secondary);
+  user-select: none;
+  line-height: 1;
+}
+
+.wb-stepper__btn {
+  border: 0;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 0.4rem 0.85rem;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.wb-stepper__btn:hover {
+  background: var(--primary);
+  color: var(--text-primary);
+}
+
+.wb-stepper__btn:active {
+  transform: translateY(1px);
+}
+
+.wb-stepper__value {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.5rem;
+  padding: 0.4rem 0.5rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+/* Input form: <input x-stepper> wrapped between the two buttons */
+.wb-stepper__input {
+  border: 0;
+  width: 3rem;
+  text-align: center;
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  font: inherit;
+}
+.wb-stepper__input:focus {
+  outline: none;
+}

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -17,6 +17,7 @@
 @import url('./behaviors/stat.css');
 @import url('./behaviors/timeline.css');
 @import url('./behaviors/steps.css');
+@import url('./behaviors/stepper.css');
 @import url('./behaviors/pagination.css');
 @import url('./behaviors/otp.css');
 @import url('./behaviors/tags.css');

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -1951,3 +1951,24 @@ section[id] {
   line-height: 1.45;
   padding-top: 0.1em;
 }
+
+/* =============================================================================
+   HOME — CLICKABLE FEATURE CARDS (#184)
+   Each Features card links to its subsystem page; the SPA intercepts ?page=.
+   ============================================================================= */
+.feature-card-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  cursor: pointer;
+  border-radius: var(--radius-lg, 0.5rem);
+}
+.feature-card-link:focus-visible {
+  outline: 2px solid var(--primary);
+  outline-offset: 3px;
+}
+/* the descendant wb-card--float already lifts on hover; ensure the whole card
+   reacts to keyboard focus on the anchor too */
+.feature-card-link:focus-visible .wb-card {
+  border-color: var(--primary);
+}

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -165,10 +165,22 @@ body > button[x-copy] {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  /* effects.css also styles the <wb-spinner> ELEMENT as a ring (legacy); the
+     schema builds an inner <div> ring, so neutralize the element ring here to
+     avoid a double ring once --border-color is defined (#182). */
+  width: auto;
+  height: auto;
+  border: 0;
+  animation: none;
 }
 
 .wb-spinner div {
-  border: 2px solid var(--border-color);
+  /* Explicit longhands instead of the `border` shorthand: if --border-color is
+     ever unset, only the color is lost, not the whole border (which previously
+     made the ring vanish entirely). #182 */
+  border-width: 2px;
+  border-style: solid;
+  border-color: var(--border-color);
   border-top-color: var(--primary);
   border-radius: 50%;
   animation: wb-spin 1.2s linear infinite;

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -1895,3 +1895,42 @@ h5, h6 {
     padding-bottom: 1.5rem;
   }
 }
+
+/* =============================================================================
+   BEHAVIORS SHOWCASE — SECTION NAV (#181)
+   pages/behaviors.css is not loaded by the SPA (see #186), so the section-nav
+   pill styling and anchor offset live here in the always-loaded shell stylesheet.
+   Selectors are safe globally: .nav-links is unique to the behaviors page, and
+   scroll-margin on anchored sections is benign everywhere.
+   ============================================================================= */
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  padding: 1rem;
+  margin-bottom: 2rem;
+  border-radius: 12px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+}
+.nav-links a {
+  text-decoration: none;
+  padding: 0.4rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  white-space: nowrap;
+  transition: all 0.2s ease;
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+}
+.nav-links a:hover {
+  background: var(--primary);
+  color: var(--text-primary);
+  border-color: var(--primary);
+}
+/* Clear the 64px sticky header when jumping to a section, otherwise the heading
+   lands hidden behind the header and the link appears not to work. */
+section[id] {
+  scroll-margin-top: 80px;
+}

--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -1934,3 +1934,20 @@ h5, h6 {
 section[id] {
   scroll-margin-top: 80px;
 }
+
+/* =============================================================================
+   BEHAVIORS SHOWCASE — HERO HEADER (#179)
+   The first content element (the ⚡ hero title) rendered ~19px under the 64px
+   sticky header, clipping the emoji and the tops of the letters with no gap.
+   Push the page content clear of the header and give the h1 line-height room
+   for the emoji's ascent. Scoped to the behaviors page.
+   ============================================================================= */
+#mainPage-behaviors {
+  padding-top: 2rem;
+}
+#mainPage-behaviors .page__hero h1,
+#mainPage-behaviors > #header h1 {
+  margin: 0;
+  line-height: 1.45;
+  padding-top: 0.1em;
+}

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -43,6 +43,14 @@
   --text-primary: hsl(220, 15%, 95%);
   --text-secondary: hsl(220, 10%, 80%);
   --text-muted: hsl(220, 10%, 60%);
+
+  /* Neutral border tone. Previously referenced by themes.css + dozens of behavior
+     styles (spinner, alert, card, button, code …) but DEFINED NOWHERE, so every
+     `border: …px solid var(--border-color)` shorthand was invalid and silently
+     dropped — invisible spinners (#182), undemarcated cards (#180), missing
+     outlines. Derived from the theme's own text color (a faint hairline) so it
+     adapts to light + dark themes without a hardcoded literal. */
+  --border-color: color-mix(in srgb, var(--text-primary) 22%, transparent);
   
   /* Semantic state colors — used by alert, notification, rating */
   --info-color: hsl(217, 91%, 60%);

--- a/src/wb-models/alert.schema.json
+++ b/src/wb-models/alert.schema.json
@@ -18,6 +18,7 @@
     "variant": {
       "type": "string",
       "description": "Alert severity/style variant",
+      "aliases": ["type"],
       "enum": [
         "info",
         "success",

--- a/src/wb-viewmodels/semantics/rating.js
+++ b/src/wb-viewmodels/semantics/rating.js
@@ -16,11 +16,20 @@
  */
 
 export function rating(element, options = {}) {
+  // Read PLAIN attributes (v3 standard: value/max/icon/color) as well as the
+  // legacy data-* form. Previously only data-*/options were read, so the
+  // showcase markup `<wb-rating value="3" icon="❤️">` was ignored — stars never
+  // filled on first paint and the custom icon was dropped. (#177)
+  const attr = (name) => element.getAttribute(name);
   const config = {
-    max: parseInt(options.max || element.dataset.max || '5', 10),
-    value: parseInt(options.value || element.dataset.value || '0', 10),
-    readonly: options.readonly ?? (element.dataset.readonly === 'true'),
-    color: options.color || element.dataset.color || '#fbbf24', // gold-400
+    max: parseInt(options.max || attr('max') || element.dataset.max || '5', 10),
+    value: parseInt(options.value || attr('value') || element.dataset.value || '0', 10),
+    readonly: options.readonly ?? (element.hasAttribute('readonly') || element.dataset.readonly === 'true'),
+    icon: options.icon || attr('icon') || element.dataset.icon || '★',
+    // Filled colour: theme's rating colour by default; override via color="…"
+    // (e.g. color="var(--primary)" for blue). Empty colour from the theme too.
+    color: options.color || attr('color') || element.dataset.color || 'var(--rating-active-color, #fbbf24)',
+    emptyColor: options.emptyColor || attr('empty-color') || 'var(--border-color, #e5e7eb)',
     ...options
   };
 
@@ -41,11 +50,11 @@ export function rating(element, options = {}) {
     const star = document.createElement('span');
     star.className = 'wb-rating__star';
     star.dataset.value = i;
-    star.innerHTML = '★'; // Unicode star
+    star.innerHTML = config.icon; // honour custom icon (★ default, ❤️/👍/…)
     star.style.fontSize = '1.5rem';
     star.style.lineHeight = '1';
     star.style.transition = 'color 0.2s ease, transform 0.1s ease';
-    star.style.color = '#e5e7eb'; // gray-200 (empty)
+    star.style.color = config.emptyColor; // empty
     
     if (!config.readonly) {
       // Hover effects
@@ -96,7 +105,7 @@ export function rating(element, options = {}) {
         star.style.color = config.color;
       } else {
         star.classList.remove('wb-rating__star--full');
-        star.style.color = '#e5e7eb';
+        star.style.color = config.emptyColor;
       }
     });
   }

--- a/src/wb-viewmodels/stepper.js
+++ b/src/wb-viewmodels/stepper.js
@@ -1,36 +1,78 @@
 // Standalone stepper behavior extracted from enhancements.js
+//
+// Supports two markup forms:
+//   1. <input x-stepper min max step value>            → wraps the input with −/+ buttons
+//   2. <div x-stepper data-value data-min data-max>     → builds [−][value][+] INSIDE the div
+// The showcase uses form (2); the original code only handled form (1), so the
+// div had no value display and reading `.value` off a <div> was always 0. (#178)
 export function stepper(element, options = {}) {
-  const config = {
-    min: parseFloat(options.min ?? element.getAttribute('min') ?? '-Infinity'),
-    max: parseFloat(options.max ?? element.getAttribute('max') ?? 'Infinity'),
-    step: parseFloat(options.step || element.getAttribute('step') || '1'),
-    ...options
+  const isInput = element.tagName === 'INPUT';
+  const num = (v, d) => {
+    const n = parseFloat(v);
+    return Number.isFinite(n) ? n : d;
   };
-  const wrapper = document.createElement('div');
-  wrapper.className = 'wb-stepper';
-  element.parentNode.insertBefore(wrapper, element);
+  const config = {
+    min: num(options.min ?? element.getAttribute('min') ?? element.dataset.min, -Infinity),
+    max: num(options.max ?? element.getAttribute('max') ?? element.dataset.max, Infinity),
+    step: num(options.step ?? element.getAttribute('step') ?? element.dataset.step, 1),
+    value: num(
+      options.value ?? element.getAttribute('value') ?? element.dataset.value ?? (isInput ? element.value : '0'),
+      0
+    ),
+    ...options,
+  };
+
   const decBtn = document.createElement('button');
   decBtn.type = 'button';
   decBtn.className = 'wb-stepper__btn wb-stepper__dec';
   decBtn.textContent = '−';
+  decBtn.setAttribute('aria-label', 'Decrease');
+
   const incBtn = document.createElement('button');
   incBtn.type = 'button';
   incBtn.className = 'wb-stepper__btn wb-stepper__inc';
   incBtn.textContent = '+';
-  wrapper.appendChild(decBtn);
-  wrapper.appendChild(element);
-  wrapper.appendChild(incBtn);
-  element.classList.add('wb-stepper__input');
+  incBtn.setAttribute('aria-label', 'Increase');
+
+  let read, write, cleanup;
+
+  if (isInput) {
+    // Form (1): wrap the input between the two buttons.
+    const wrapper = document.createElement('div');
+    wrapper.className = 'wb-stepper';
+    element.parentNode.insertBefore(wrapper, element);
+    wrapper.appendChild(decBtn);
+    wrapper.appendChild(element);
+    wrapper.appendChild(incBtn);
+    element.classList.add('wb-stepper__input');
+    element.value = config.value;
+    read = () => num(element.value, 0);
+    write = (v) => { element.value = v; element.dispatchEvent(new Event('change')); };
+    cleanup = () => { wrapper.parentNode.insertBefore(element, wrapper); wrapper.remove(); };
+  } else {
+    // Form (2): build [−][value][+] inside the container so the value is visible
+    // and the buttons are discoverable as children of the [x-stepper] element.
+    element.classList.add('wb-stepper');
+    element.textContent = '';
+    const valueEl = document.createElement('span');
+    valueEl.className = 'wb-stepper__value';
+    valueEl.textContent = String(config.value);
+    element.appendChild(decBtn);
+    element.appendChild(valueEl);
+    element.appendChild(incBtn);
+    read = () => num(valueEl.textContent, 0);
+    write = (v) => { valueEl.textContent = String(v); };
+    cleanup = () => { element.textContent = ''; element.classList.remove('wb-stepper'); };
+  }
+
   const updateValue = (delta) => {
-    let value = parseFloat(element.value) || 0;
-    value = Math.max(config.min, Math.min(config.max, value + delta));
-    element.value = value;
-    element.dispatchEvent(new Event('change'));
+    const value = Math.max(config.min, Math.min(config.max, read() + delta));
+    write(value);
+    element.dispatchEvent(new CustomEvent('wb:stepper:change', { bubbles: true, detail: { value } }));
   };
+
   decBtn.onclick = () => updateValue(-config.step);
   incBtn.onclick = () => updateValue(config.step);
-  return () => {
-    wrapper.parentNode.insertBefore(element, wrapper);
-    wrapper.remove();
-  };
+
+  return cleanup;
 }

--- a/tests/behaviors/alerts-variants.spec.ts
+++ b/tests/behaviors/alerts-variants.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * #176 — <wb-alert> must honor the `type=` attribute as an alias for `variant`.
+ * The showcase authors alerts as `type="success|warning|error"`, but the schema
+ * property is `variant` (default "info"), so every alert rendered blue. The
+ * schema-builder now supports property aliases (extractData) and the alert schema
+ * declares variant.aliases = ["type"].
+ */
+import { test, expect } from '@playwright/test';
+
+test('#176 — alert type= maps to variant: four distinct colors', async ({ page }) => {
+  await page.goto('http://localhost:3000/?page=behaviors');
+  await page.waitForSelector('#mainPage-behaviors', { timeout: 20000 });
+  await page.waitForTimeout(2500); // lazy injection + schema build
+
+  const info = await page.locator('wb-alert[type="info"], wb-alert.wb-alert--info').first();
+  await expect(info, 'no alerts found on showcase').toBeVisible();
+
+  // Each type= alert should carry the matching wb-alert--<type> class…
+  const classMatch = await page.evaluate(() => {
+    const types = ['info', 'success', 'warning', 'error'];
+    return types.map((t) => {
+      const el = document.querySelector(`wb-alert[type="${t}"]`);
+      return { t, hasClass: !!el && el.classList.contains(`wb-alert--${t}`) };
+    });
+  });
+  for (const { t, hasClass } of classMatch) {
+    expect(hasClass, `wb-alert[type="${t}"] did not get class wb-alert--${t}`).toBe(true);
+  }
+
+  // …and the four variants must be visually distinct (not all "info" blue).
+  const colors = await page.evaluate(() =>
+    ['info', 'success', 'warning', 'error'].map((t) => {
+      const el = document.querySelector(`wb-alert[type="${t}"]`) as HTMLElement;
+      return el ? getComputedStyle(el).backgroundColor : 'MISSING';
+    })
+  );
+  expect(
+    new Set(colors).size,
+    `alert variants not distinct (type= ignored?): ${colors.join(', ')}`
+  ).toBe(4);
+});

--- a/tests/behaviors/cards-demarcated.spec.ts
+++ b/tests/behaviors/cards-demarcated.spec.ts
@@ -1,0 +1,42 @@
+/**
+ * #180 — cards must read as discrete, demarcated cards.
+ *
+ * Two root causes: (1) --border-color was undefined so the 1px card border was
+ * dropped (fixed in #182), and (2) variant="float" — the most-used card variant —
+ * had NO CSS rule, so float cards fell back to the flat base with no elevation.
+ * Added .wb-card--float (+ --cosmic) with elevation in card.css.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('#180 — cards are demarcated', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:3000/?page=cards');
+    await page.waitForSelector('wb-card', { timeout: 20000 });
+    await page.waitForTimeout(1500);
+  });
+
+  test('card border is rendered (not dropped by undefined --border-color)', async ({ page }) => {
+    const r = await page.evaluate(() => {
+      const c = document.querySelector('wb-card') as HTMLElement;
+      if (!c) return null;
+      const cs = getComputedStyle(c);
+      return {
+        borderTopWidth: parseFloat(cs.borderTopWidth),
+        bg: cs.backgroundColor,
+        pageBg: getComputedStyle(document.body).backgroundColor,
+      };
+    });
+    expect(r, 'no wb-card on page').not.toBeNull();
+    expect(r!.borderTopWidth, 'card has no border').toBeGreaterThanOrEqual(1);
+    expect(r!.bg, 'card background matches page (no demarcation)').not.toBe(r!.pageBg);
+  });
+
+  test('float variant has real elevation (box-shadow)', async ({ page }) => {
+    const shadow = await page.evaluate(() => {
+      const c = document.querySelector('wb-card[variant="float"]') as HTMLElement;
+      return c ? getComputedStyle(c).boxShadow : 'NO_FLOAT_CARD';
+    });
+    expect(shadow, 'no variant="float" card found').not.toBe('NO_FLOAT_CARD');
+    expect(shadow, 'float card has no box-shadow (no elevation → undemarcated)').not.toBe('none');
+  });
+});

--- a/tests/behaviors/code-highlight.spec.ts
+++ b/tests/behaviors/code-highlight.spec.ts
@@ -1,0 +1,45 @@
+/**
+ * #183 — showcase code blocks must render like a code editor (highlight.js syntax
+ * tokens, monospace, dark theme), not raw text.
+ *
+ * The breakage was a side effect of the wb-demo disconnect crash (#174/#175) which
+ * tore down rendering, plus the missing highlight theme. This regression test locks
+ * the working state: every demo code block is highlighted.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('#183 — code blocks highlight', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:3000/?page=behaviors');
+    await page.waitForSelector('#mainPage-behaviors', { timeout: 20000 });
+    await page.waitForTimeout(2500); // demo build + highlight.js
+  });
+
+  test('demo code blocks carry the hljs class and token spans', async ({ page }) => {
+    const r = await page.evaluate(() => {
+      const blocks = [...document.querySelectorAll('pre code, code.language-html')];
+      const highlighted = blocks.filter((c) => c.classList.contains('hljs'));
+      const withTokens = highlighted.filter((c) => c.querySelector('[class^="hljs-"]'));
+      return { total: blocks.length, highlighted: highlighted.length, withTokens: withTokens.length };
+    });
+    expect(r.total, 'no code blocks on showcase').toBeGreaterThan(5);
+    expect(r.highlighted, 'code blocks not highlighted (no hljs class)').toBeGreaterThan(5);
+    expect(r.withTokens, 'highlighted blocks have no syntax token spans').toBeGreaterThan(5);
+  });
+
+  test('code blocks render in a monospace font (editor-like)', async ({ page }) => {
+    const font = await page.evaluate(() => {
+      const c = document.querySelector('pre code.hljs, code.hljs') as HTMLElement;
+      return c ? getComputedStyle(c).fontFamily.toLowerCase() : 'NONE';
+    });
+    expect(font).not.toBe('NONE');
+    expect(font, `code font is not monospace: ${font}`).toMatch(/mono|consolas|menlo|courier/);
+  });
+
+  test('highlight theme stylesheet is loaded', async ({ page }) => {
+    const loaded = await page.evaluate(() =>
+      [...document.styleSheets].some((s) => /highlight|atom-one|hljs/i.test(s.href || ''))
+    );
+    expect(loaded, 'no highlight.js theme stylesheet loaded').toBe(true);
+  });
+});

--- a/tests/behaviors/hero-header.spec.ts
+++ b/tests/behaviors/hero-header.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * #179 — the behaviors hero title (⚡ WB Behaviors Showcase) must clear the 64px
+ * sticky site header. It was rendering ~19px under the header, clipping the ⚡
+ * glyph and the tops of the letters with no gap.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('#179 — behaviors hero clears the sticky header', () => {
+  test('hero title is fully below the header with a gap (not clipped)', async ({ page }) => {
+    await page.goto('http://localhost:3000/?page=behaviors');
+    await page.waitForSelector('#mainPage-behaviors', { timeout: 20000 });
+    await page.waitForTimeout(1500);
+    // ensure we're at the very top
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await page.waitForTimeout(200);
+
+    const r = await page.evaluate(() => {
+      const header = document.querySelector('.site__header') as HTMLElement;
+      const h1 = document.querySelector('#mainPage-behaviors h1') as HTMLElement;
+      if (!header || !h1) return null;
+      return {
+        headerBottom: Math.round(header.getBoundingClientRect().bottom),
+        h1Top: Math.round(h1.getBoundingClientRect().top),
+      };
+    });
+    expect(r, 'header or hero h1 missing').not.toBeNull();
+    // title top must be at/under the header bottom, with a real gap (not clipped)
+    expect(
+      r!.h1Top,
+      `hero title top (${r!.h1Top}) is above header bottom (${r!.headerBottom}) — clipped`
+    ).toBeGreaterThanOrEqual(r!.headerBottom);
+  });
+
+  test('hero h1 has line-height room for the emoji ascent', async ({ page }) => {
+    await page.goto('http://localhost:3000/?page=behaviors');
+    await page.waitForSelector('#mainPage-behaviors h1', { timeout: 20000 });
+    const ratio = await page.evaluate(() => {
+      const h1 = document.querySelector('#mainPage-behaviors h1') as HTMLElement;
+      const cs = getComputedStyle(h1);
+      return parseFloat(cs.lineHeight) / parseFloat(cs.fontSize);
+    });
+    expect(ratio, `h1 line-height ratio ${ratio} too tight for emoji`).toBeGreaterThanOrEqual(1.3);
+  });
+});

--- a/tests/behaviors/rating-icon-value.spec.ts
+++ b/tests/behaviors/rating-icon-value.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * #177 — <wb-rating> must honor the custom icon, paint its value on first render,
+ * and use theme colors (overridable via color=).
+ *
+ * The behavior only read data-attributes and options, so the plain attributes
+ * (value="3" icon="❤️") were ignored: every rating showed empty ★ stars. Now it
+ * reads plain attributes and honors icon + theme color (--rating-active-color).
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('#177 — rating icon + value + color', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:3000/?page=behaviors');
+    await page.waitForSelector('#mainPage-behaviors', { timeout: 20000 });
+    await page.waitForTimeout(2000);
+  });
+
+  test('custom icon= is honored (hearts / thumbs, not stars)', async ({ page }) => {
+    const glyphs = await page.evaluate(() =>
+      ['❤️', '👍'].map((ic) => {
+        const r = document.querySelector(`wb-rating[icon="${ic}"]`);
+        const first = r?.querySelector('.wb-rating__star');
+        return { icon: ic, glyph: first?.textContent || '' };
+      })
+    );
+    for (const g of glyphs) {
+      expect(g.glyph, `rating icon="${g.icon}" still shows "${g.glyph}"`).toBe(g.icon);
+    }
+  });
+
+  test('value is painted on first render (filled count == value)', async ({ page }) => {
+    const r = await page.evaluate(() => {
+      return [...document.querySelectorAll('wb-rating')].map((el) => {
+        const value = parseInt(el.getAttribute('value') || '0', 10);
+        const filled = el.querySelectorAll('.wb-rating__star--full').length;
+        return { value, filled };
+      });
+    });
+    expect(r.length).toBeGreaterThanOrEqual(3);
+    for (const { value, filled } of r) {
+      expect(filled, `rating value=${value} painted ${filled} filled on first render`).toBe(value);
+    }
+  });
+
+  test('filled stars use the theme rating color, not a hardcoded gray', async ({ page }) => {
+    const color = await page.evaluate(() => {
+      const star = document.querySelector('wb-rating .wb-rating__star--full') as HTMLElement;
+      return star ? getComputedStyle(star).color : 'NONE';
+    });
+    // --rating-active-color resolves to gold rgb(251, 197, 35)
+    expect(color).not.toBe('NONE');
+    expect(color, 'filled star is not colored').not.toBe('rgba(0, 0, 0, 0)');
+  });
+});

--- a/tests/behaviors/section-nav.spec.ts
+++ b/tests/behaviors/section-nav.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * #181 — the behaviors-page section nav links must (a) read as distinct pills
+ * (not crowded text) and (b) jump to their section with the heading clear of the
+ * 64px sticky header (previously they landed hidden behind it, appearing dead).
+ *
+ * Fix: .nav-links pills get a background/border; section[id] gets scroll-margin-top.
+ */
+import { test, expect } from '@playwright/test';
+
+const SECTION_IDS = ['buttons', 'inputs', 'selection', 'feedback', 'overlays', 'navigation', 'data', 'media', 'effects', 'utilities'];
+
+test.describe('#181 — section nav links', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:3000/?page=behaviors');
+    await page.waitForSelector('.nav-links', { timeout: 20000 });
+    await page.waitForTimeout(2500);
+  });
+
+  test('every section link resolves to an existing target', async ({ page }) => {
+    const dead = await page.evaluate((ids) => {
+      const links = [...document.querySelectorAll('.nav-links a[href^="#"]')];
+      return links
+        .map((a) => a.getAttribute('href') || '')
+        .filter((h) => h.length > 1 && !document.querySelector(h));
+    }, SECTION_IDS);
+    expect(dead, `nav links point to missing anchors: ${dead.join(', ')}`).toEqual([]);
+  });
+
+  test('nav pills are visible chips (have a background, not crowded text)', async ({ page }) => {
+    const bg = await page.evaluate(() => {
+      const a = document.querySelector('.nav-links a') as HTMLElement;
+      return a ? getComputedStyle(a).backgroundColor : 'NONE';
+    });
+    expect(bg).not.toBe('NONE');
+    expect(bg, 'nav pill has no background (reads as crowded text)').not.toBe('rgba(0, 0, 0, 0)');
+  });
+
+  test('sections have scroll-margin to clear the sticky header', async ({ page }) => {
+    const margins = await page.evaluate((ids) =>
+      ids.map((id) => {
+        const el = document.getElementById(id);
+        return { id, sm: el ? parseFloat(getComputedStyle(el).scrollMarginTop) : -1 };
+      }),
+      SECTION_IDS
+    );
+    for (const { id, sm } of margins) {
+      expect(sm, `#${id} has no scroll-margin-top (heading would hide under header)`).toBeGreaterThanOrEqual(64);
+    }
+  });
+
+  test('clicking a section link scrolls it into view below the header', async ({ page }) => {
+    await page.evaluate(() => window.scrollTo(0, 0));
+    await page.waitForTimeout(150);
+    await page.click('.nav-links a[href="#data"]');
+    await page.waitForTimeout(1500); // allow smooth scroll over a long distance to settle
+    const top = await page.evaluate(() => Math.round(document.getElementById('data')!.getBoundingClientRect().top));
+    // landed near the top, but clear of the 64px header (scroll-margin-top: 80)
+    expect(top, `#data landed at ${top}px (expected ~80, below the 64px header)`).toBeGreaterThanOrEqual(40);
+    expect(top, `#data did not scroll into view (top=${top})`).toBeLessThanOrEqual(120);
+  });
+});

--- a/tests/behaviors/spinners-visible.spec.ts
+++ b/tests/behaviors/spinners-visible.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * #182 — <wb-spinner> must render a visible, animated ring.
+ *
+ * Root cause: `--border-color` was referenced by the spinner CSS (and many other
+ * behaviors) but defined in NO theme. `border: 2px solid var(--border-color)` with
+ * an undefined var is an invalid shorthand, so the entire border was dropped — the
+ * ring spun but was invisible. Fixed by defining --border-color in themes.css and
+ * using explicit border longhands + neutralizing effects.css's element-level ring.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('#182 — spinners visible + animated', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:3000/?page=behaviors');
+    await page.waitForSelector('#mainPage-behaviors', { timeout: 20000 });
+    await page.waitForTimeout(2000);
+  });
+
+  test('--border-color theme variable is defined', async ({ page }) => {
+    const v = await page.evaluate(() =>
+      getComputedStyle(document.documentElement).getPropertyValue('--border-color').trim()
+    );
+    expect(v, '--border-color is undefined (would drop every border that uses it)').not.toBe('');
+  });
+
+  test('every spinner ring has a visible border and is animated', async ({ page }) => {
+    const rings = await page.evaluate(() =>
+      [...document.querySelectorAll('wb-spinner')].map((sp) => {
+        const inner = sp.querySelector('div') as HTMLElement;
+        const ics = inner ? getComputedStyle(inner) : null;
+        return {
+          hasInner: !!inner,
+          borderTopWidth: ics ? parseFloat(ics.borderTopWidth) : 0,
+          anim: ics ? ics.animationName : 'none',
+          color: ics ? ics.borderTopColor : '',
+        };
+      })
+    );
+    expect(rings.length, 'no spinners on showcase').toBeGreaterThanOrEqual(4);
+    for (const r of rings) {
+      expect(r.hasInner, 'spinner has no inner ring element').toBe(true);
+      expect(r.borderTopWidth, 'spinner ring border is 0 (invisible)').toBeGreaterThanOrEqual(1.5);
+      expect(r.anim, 'spinner ring is not animated').toBe('wb-spin');
+    }
+  });
+
+  test('spinner color= variants render distinct colors', async ({ page }) => {
+    const colors = await page.evaluate(() =>
+      ['success', 'warning', 'error'].map((c) => {
+        const sp = document.querySelector(`wb-spinner[color="${c}"]`);
+        const inner = sp?.querySelector('div') as HTMLElement;
+        return inner ? getComputedStyle(inner).borderTopColor : 'MISSING';
+      })
+    );
+    expect(new Set(colors).size, `spinner color= variants not distinct: ${colors.join(', ')}`).toBe(3);
+  });
+});

--- a/tests/behaviors/stepper-range.spec.ts
+++ b/tests/behaviors/stepper-range.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * #178 — the [x-stepper] control and the range slider must be interactive.
+ *
+ * The stepper behavior assumed its element was an <input> and read .value off a
+ * <div> (always 0), so the showcase's <div x-stepper data-value data-min data-max>
+ * showed no value and the buttons did nothing visible. Now it builds
+ * [−][value][+] inside the container and honors data-value/min/max.
+ */
+import { test, expect } from '@playwright/test';
+
+test.describe('#178 — stepper + range', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:3000/?page=behaviors');
+    await page.waitForSelector('#mainPage-behaviors', { timeout: 20000 });
+    await page.waitForTimeout(2000);
+  });
+
+  test('stepper renders [-][value][+] with its data-value', async ({ page }) => {
+    const r = await page.evaluate(() => {
+      const st = document.querySelector('[x-stepper]');
+      return st
+        ? {
+            buttons: st.querySelectorAll('button').length,
+            value: st.querySelector('.wb-stepper__value')?.textContent,
+          }
+        : null;
+    });
+    expect(r, 'no [x-stepper] element').not.toBeNull();
+    expect(r!.buttons, 'stepper has no +/- buttons').toBe(2);
+    expect(r!.value, 'stepper does not show its data-value').toBe('5');
+  });
+
+  test('stepper + increments and clamps to data-max', async ({ page }) => {
+    const result = await page.evaluate(async () => {
+      const st = document.querySelector('[x-stepper]') as HTMLElement;
+      const valEl = st.querySelector('.wb-stepper__value') as HTMLElement;
+      const inc = st.querySelector('.wb-stepper__inc') as HTMLButtonElement;
+      const dec = st.querySelector('.wb-stepper__dec') as HTMLButtonElement;
+      const start = valEl.textContent;
+      inc.click();
+      const afterInc = valEl.textContent;
+      // clamp test: data-max=10, click + many times
+      for (let i = 0; i < 20; i++) inc.click();
+      const atMax = valEl.textContent;
+      // clamp low: data-min=0
+      for (let i = 0; i < 30; i++) dec.click();
+      const atMin = valEl.textContent;
+      return { start, afterInc, atMax, atMin };
+    });
+    expect(result.afterInc, 'stepper + did not increment').toBe('6');
+    expect(result.atMax, 'stepper did not clamp to data-max=10').toBe('10');
+    expect(result.atMin, 'stepper did not clamp to data-min=0').toBe('0');
+  });
+
+  test('range slider is present, themed, and accepts input', async ({ page }) => {
+    const r = await page.evaluate(() => {
+      const rg = document.querySelector('#mainPage-behaviors input[type="range"]') as HTMLInputElement;
+      if (!rg) return null;
+      rg.value = '80';
+      rg.dispatchEvent(new Event('input', { bubbles: true }));
+      return {
+        width: Math.round(rg.getBoundingClientRect().width),
+        accent: getComputedStyle(rg).accentColor,
+        value: rg.value,
+      };
+    });
+    expect(r, 'no range input').not.toBeNull();
+    expect(r!.width, 'range has no width').toBeGreaterThan(20);
+    expect(r!.value, 'range did not accept input').toBe('80');
+  });
+});

--- a/tests/views/feature-cards-clickable.spec.ts
+++ b/tests/views/feature-cards-clickable.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * #184 — the home page Features cards must be clickable and navigate to their
+ * subsystem pages (via the SPA ?page= router).
+ */
+import { test, expect } from '@playwright/test';
+
+const EXPECTED = [
+  { title: 'Component Library', href: '?page=components' },
+  { title: 'Behaviors System', href: '?page=behaviors' },
+  { title: 'Theme Engine', href: '?page=themes' },
+  { title: 'Data Viz', href: '?page=demos' },
+  { title: 'Accessible', href: '?page=docs' },
+  { title: 'Performance', href: '?page=docs' },
+];
+
+test.describe('#184 — home feature cards are clickable', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('http://localhost:3000/?page=home');
+    await page.waitForSelector('.feature-card-link', { timeout: 20000 });
+    await page.waitForTimeout(1000);
+  });
+
+  test('each feature card is an anchor to a ?page= route', async ({ page }) => {
+    const links = await page.evaluate(() =>
+      [...document.querySelectorAll('.feature-card-link')].map((a) => ({
+        href: a.getAttribute('href'),
+        title: (a.querySelector('h3')?.textContent || '').replace(/^[^A-Za-z]+/, '').trim(),
+        hasCard: !!a.querySelector('wb-card'),
+        underline: getComputedStyle(a as HTMLElement).textDecorationLine,
+      }))
+    );
+    expect(links.length, 'expected 6 feature cards').toBe(6);
+    for (const exp of EXPECTED) {
+      const found = links.find((l) => l.title.startsWith(exp.title));
+      expect(found, `feature card "${exp.title}" not found`).toBeTruthy();
+      expect(found!.href, `"${exp.title}" links to wrong route`).toBe(exp.href);
+      expect(found!.hasCard, `"${exp.title}" anchor does not wrap a wb-card`).toBe(true);
+      expect(found!.underline, 'feature card link should not be underlined').toBe('none');
+    }
+  });
+
+  test('clicking a feature card navigates via the SPA', async ({ page }) => {
+    await page.click('.feature-card-link[href="?page=components"]');
+    await page.waitForTimeout(800);
+    const url = await page.evaluate(() => location.search);
+    expect(url, 'clicking the Component Library card did not navigate').toContain('page=components');
+  });
+});


### PR DESCRIPTION
@
Fixes the full batch of behaviors-showcase / home regressions. Each fix ships with a named regression test (run with `--project=behaviors`/`views --grep "#NNN"`).

| # | Fix | Root cause | Test |
|---|-----|-----------|------|
| #176 | Alert `type=` honored | markup used `type=`, schema read `variant` → all blue | `alerts-variants.spec.ts` |
| #182 | Spinners visible | `--border-color` undefined → `border: …var(--border-color)` shorthand invalid → ring dropped | `spinners-visible.spec.ts` |
| #180 | Cards demarcated | same `--border-color` + `variant="float"` had no CSS | `cards-demarcated.spec.ts` |
| #177 | Rating icon/value/color | behavior read only `data-*`, ignored plain `value=`/`icon=` | `rating-icon-value.spec.ts` |
| #178 | Stepper interactive | behavior assumed `<input>`, read `.value` off a `<div>` | `stepper-range.spec.ts` |
| #181 | Section nav pills + scroll | `pages/behaviors.css` never loads in SPA (#186); native anchor scroll undone by reflow | `section-nav.spec.ts` |
| #183 | Code blocks highlight | side effect of the wb-demo crash (#174/#175); now locked | `code-highlight.spec.ts` |
| #179 | Hero ⚡ un-clipped | hero rendered ~19px under the 64px sticky header | `hero-header.spec.ts` |
| #184 | Feature cards clickable | cards werent linked to subsystem pages | `feature-cards-clickable.spec.ts` |

## Key shared fix
`--border-color` was referenced by themes.css + dozens of behavior styles but **defined in no theme** — silently dropping every border that used it. Now derived from the theme text color via `color-mix` (themes.css), which fixes spinners (#182), cards (#180), and alert/button outlines in one go.

## Verification
Every fix verified individually (browser inspect + screenshots) and by its named Playwright test. The schema-builder change (alias support + only claiming registered `wb-*` tags) is purely additive and proven equivalent to `main` on the pre-existing auto-injection failures.

## Follow-ups filed
- #186 — SPA never loads `pages/*.css` (page stylesheets are dead; behaviors.css also has unscoped header/footer rules). The #181 pill styling lives in site.css as a stopgap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@