### PR TITLE
fix(#186 + layout): single scroll container, sticky nav, section spacing

### DIFF
--- a/src/styles/site.css
+++ b/src/styles/site.css
@@ -69,7 +69,11 @@ body { margin: 0; font-family: system-ui, -apple-system, sans-serif; }
 }
 
 .site {
-  min-height: 100vh;
+  /* Fixed to the viewport + clip overflow so .site__body is the SINGLE scroll
+     container (was min-height:100vh, which let the whole window scroll too — a
+     dual-scroll-container bug that broke the sticky nav and section anchoring). */
+  height: 100vh;
+  overflow: hidden;
   display: flex;
   flex-direction: column;
   background: var(--bg-color);
@@ -266,10 +270,14 @@ body > button[x-copy] {
   flex-direction: column;
   transition: width 0.3s ease;
   overflow: visible; /* Changed from hidden to allow resizer handle */
-  /* Sticky sidebar support */
+  /* Sticky sidebar — stay pinned to the viewport as the content scrolls, so the
+     menu is always at the user's current location (was position:relative, which
+     scrolled the nav off-screen). */
   align-self: flex-start;
+  position: sticky;
+  top: 0;
   max-height: calc(100vh - 60px);
-  position: relative;
+  overflow-y: auto;
 }
 
 .site__nav--collapsed {
@@ -1973,4 +1981,38 @@ section[id] {
    reacts to keyboard focus on the anchor too */
 .feature-card-link:focus-visible .wb-card {
   border-color: var(--primary);
+}
+
+/* =============================================================================
+   PAGE SECTION RHYTHM (#186)
+   pages/*.css never loads in the SPA, so the section/heading/section-note
+   spacing lives here in the always-loaded shell stylesheet, scoped to the SPA
+   content container (#main) so it can't touch the shell. Restores the vertical
+   spacing the showcase pages were designed with.
+   ============================================================================= */
+#main section[id] {
+  margin-bottom: 2.5rem;
+  padding-bottom: 0.5rem;
+}
+#main section > h2 {
+  margin: 2.5rem 0 1rem;
+  font-size: 1.5rem;
+}
+#main section > h3 {
+  margin: 1.75rem 0 0.75rem;
+  font-size: 1.125rem;
+}
+#main .section-note {
+  padding: 0.75rem 1rem;
+  margin: 0 0 1.25rem;
+  border-left: 3px solid var(--primary);
+  border-radius: 0 8px 8px 0;
+  background: var(--bg-secondary);
+  font-size: 0.9rem;
+}
+#main .demo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
 }

--- a/tests/views/nav-sticky.spec.ts
+++ b/tests/views/nav-sticky.spec.ts
@@ -1,0 +1,41 @@
+/**
+ * The side nav must stay pinned to the viewport as the page scrolls (so opening
+ * the menu always shows it at the user's current location), and the page must use
+ * a SINGLE scroll container (.site__body) — not also scroll the window.
+ */
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WB_BASE || 'http://localhost:3000';
+
+test.describe('Side nav stays at the current scroll location', () => {
+  test('nav is sticky and pinned while .site__body scrolls', async ({ page }) => {
+    await page.goto(`${BASE}/?page=themes`, { waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('.site__nav', { timeout: 25000 });
+    await page.waitForTimeout(1500);
+
+    const r = await page.evaluate(async () => {
+      const nav = document.querySelector('.site__nav') as HTMLElement;
+      const body = document.querySelector('.site__body') as HTMLElement;
+      const navTop = () => Math.round(nav.getBoundingClientRect().top);
+      body.scrollTop = 0;
+      await new Promise((r) => setTimeout(r, 60));
+      const t0 = navTop();
+      body.scrollTop = 800;
+      await new Promise((r) => setTimeout(r, 80));
+      const t800 = navTop();
+      return {
+        position: getComputedStyle(nav).position,
+        bodyCanScroll: body.scrollHeight > body.clientHeight + 50,
+        windowScrollY: Math.round(window.scrollY),
+        t0,
+        t800,
+      };
+    });
+
+    expect(r.position, 'nav should be position:sticky').toBe('sticky');
+    expect(r.bodyCanScroll, '.site__body should be the scroll container').toBe(true);
+    expect(r.windowScrollY, 'window should not scroll (single scroll container)').toBeLessThan(20);
+    // nav stays at (roughly) the same viewport position while the body scrolls
+    expect(Math.abs(r.t0 - r.t800), `nav drifted on scroll (t0=${r.t0} t800=${r.t800})`).toBeLessThan(12);
+  });
+});


### PR DESCRIPTION
Single scroll container (.site height:100vh/overflow:hidden) so the nav can be sticky and section anchors work; sticky side nav; and the #186 section/heading spacing moved into the shell stylesheet (scoped to #main) since pages/*.css never loads in the SPA. nav-sticky.spec.ts passing.