### PR TITLE
fix(#199): code blocks render editor-style (no mid-token wrapping)

### DIFF
--- a/src/wb-viewmodels/semantics/pre.js
+++ b/src/wb-viewmodels/semantics/pre.js
@@ -19,8 +19,10 @@ export function pre(element, options = {}) {
   const childLanguage = codeChild ? (codeChild.dataset.language || '') : '';
 
   const scrollable = options.scrollable ?? (element.dataset.scrollable === 'true');
-  // If scrollable is false (default), we wrap text. If true, we don't wrap (unless wrap is explicitly forced).
-  const defaultWrap = !scrollable;
+  // Code blocks should read like a code editor: DO NOT wrap by default (wrapping
+  // breaks tokens mid-word, e.g. "wb-btn--" / "sm"). Long lines scroll
+  // horizontally instead. Opt into wrapping explicitly with data-wrap="true". (#199)
+  const defaultWrap = false;
 
   const config = {
     language: options.language || element.dataset.language || childLanguage || '',
@@ -55,10 +57,13 @@ export function pre(element, options = {}) {
     backgroundColor: 'transparent', // Wrapper handles bg
     color: 'var(--text-code, #d4d4d4)',
     border: 'none', // Wrapper handles border
-    overflow: config.scrollable ? 'auto' : 'hidden',
+    // No-wrap code scrolls horizontally (editor style); wrapped code hides overflow.
+    overflowX: config.wrap ? 'hidden' : 'auto',
+    overflowY: config.maxHeight ? 'auto' : 'hidden',
     whiteSpace: config.wrap ? 'pre-wrap' : 'pre',
-    wordBreak: 'break-word', // Always break long words to prevent overflow
-    overflowWrap: 'break-word',
+    // Only break words when wrapping — never mangle tokens in editor (pre) mode.
+    wordBreak: config.wrap ? 'break-word' : 'normal',
+    overflowWrap: config.wrap ? 'break-word' : 'normal',
     margin: '0',
     width: '100%',
     maxWidth: '100%',

--- a/tests/behaviors/code-format.spec.ts
+++ b/tests/behaviors/code-format.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * Showcase code blocks must read like a code editor: lines preserved (no
+ * mid-token wrapping), long lines scroll horizontally. (#199 / pre.js)
+ */
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WB_BASE || 'http://localhost:3000';
+const URL = `${BASE.replace(/\/$/, '')}/?page=behaviors`;
+
+test('demo code blocks do not wrap/break tokens (editor style, horizontal scroll)', async ({ page }) => {
+  await page.goto(URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('#mainPage-behaviors', { timeout: 25000 });
+  await page.waitForTimeout(2800);
+
+  const r = await page.evaluate(() => {
+    const pre = document.querySelector('pre.x-pre, .x-pre-wrapper pre, .wb-demo__code') as HTMLElement;
+    if (!pre) return null;
+    const cs = getComputedStyle(pre);
+    return { whiteSpace: cs.whiteSpace, overflowX: cs.overflowX, wordBreak: cs.wordBreak };
+  });
+
+  expect(r, 'no demo code block found').not.toBeNull();
+  expect(r!.whiteSpace, `code wraps (white-space=${r!.whiteSpace}); should be pre`).toBe('pre');
+  expect(['auto', 'scroll'], `code does not scroll horizontally (overflow-x=${r!.overflowX})`).toContain(r!.overflowX);
+  expect(r!.wordBreak, `code breaks tokens (word-break=${r!.wordBreak})`).not.toBe('break-word');
+});


### PR DESCRIPTION
pre.js defaulted to wrap+word-break, mangling tokens. Now no-wrap + horizontal scroll (editor style). code-format.spec.ts passing.