### PR TITLE
fix(#201): theme-accent native checkboxes/radios

### DIFF
--- a/src/styles/behaviors/input.css
+++ b/src/styles/behaviors/input.css
@@ -132,3 +132,10 @@ input:not([type="range"]):not([type="checkbox"]):not([type="radio"])::placeholde
 textarea::placeholder {
   color: var(--text-muted);
 }
+
+/* Native checkbox/radio: theme-accent the control (was browser default). #201 */
+input[type="checkbox"],
+input[type="radio"] {
+  accent-color: var(--primary);
+  cursor: pointer;
+}


### PR DESCRIPTION
accent-color: var(--primary) on checkbox/radio so they follow the theme instead of browser-default blue/grey. Part of #201.