### PR TITLE
fix(#210): Dark Mode switch toggles theme + fix darkmode behavior

### DIFF
--- a/pages/behaviors.html
+++ b/pages/behaviors.html
@@ -119,7 +119,7 @@
 
     <h3>Switch Toggle</h3>
     <wb-demo>
-      <wb-switch label="Dark Mode"></wb-switch>
+      <wb-switch label="Dark Mode" theme-control></wb-switch>
       <wb-switch label="Notifications" checked></wb-switch>
       <wb-switch label="Disabled" disabled></wb-switch>
     </wb-demo>

--- a/src/wb-viewmodels/darkmode.js
+++ b/src/wb-viewmodels/darkmode.js
@@ -24,18 +24,18 @@ export function darkmode(element, options = {}) {
   }
 
   // Store original theme
-  const originalTheme = targetEl.getAttribute('theme');
+  const originalTheme = targetEl.getAttribute('data-theme');
 
   // Apply dark theme immediately
-  targetEl.setAttribute('theme', config.theme);
+  targetEl.setAttribute('data-theme', config.theme);
   element.classList.add('wb-darkmode');
 
   // If element is a button, make it toggle
   if (element.tagName === 'BUTTON') {
     element.onclick = () => {
-      const current = targetEl.getAttribute('theme');
+      const current = targetEl.getAttribute('data-theme');
       const next = current === 'dark' ? 'light' : 'dark';
-      targetEl.setAttribute('theme', next);
+      targetEl.setAttribute('data-theme', next);
       
       element.dispatchEvent(new CustomEvent('wb:darkmode:toggle', {
         bubbles: true,
@@ -55,9 +55,9 @@ export function darkmode(element, options = {}) {
   return () => {
     element.classList.remove('wb-darkmode');
     if (originalTheme) {
-      targetEl.setAttribute('theme', originalTheme);
+      targetEl.setAttribute('data-theme', originalTheme);
     } else {
-      delete targetEl.getAttribute('theme');
+      delete targetEl.getAttribute('data-theme');
     }
   };
 }

--- a/src/wb-viewmodels/semantics/switch.js
+++ b/src/wb-viewmodels/semantics/switch.js
@@ -71,10 +71,22 @@ export function switchInput(element, options = {}) {
   if (!isBareCheckbox) host.addEventListener('keydown', onKey);
   input.addEventListener('change', sync);
 
+  // Optional: <wb-switch theme-control> drives the page theme (data-theme).
+  // ON = dark, OFF = light. Initial state reflects the current theme. (#210)
+  let applyTheme = null;
+  if (!isBareCheckbox && host.hasAttribute('theme-control')) {
+    const root = document.documentElement;
+    input.checked = (root.getAttribute('data-theme') || 'dark') !== 'light';
+    sync();
+    applyTheme = () => root.setAttribute('data-theme', input.checked ? 'dark' : 'light');
+    input.addEventListener('change', applyTheme);
+  }
+
   return () => {
     host.removeEventListener('click', onClick);
     host.removeEventListener('keydown', onKey);
     input.removeEventListener('change', sync);
+    if (applyTheme) input.removeEventListener('change', applyTheme);
   };
 }
 

--- a/tests/behaviors/code-format.spec.ts
+++ b/tests/behaviors/code-format.spec.ts
@@ -1,26 +1,35 @@
 /**
  * Showcase code blocks must read like a code editor: lines preserved (no
  * mid-token wrapping), long lines scroll horizontally. (#199 / pre.js)
+ * Checks EVERY code block, fresh load (no cache).
  */
 import { test, expect } from '@playwright/test';
 
 const BASE = process.env.WB_BASE || 'http://localhost:3000';
 const URL = `${BASE.replace(/\/$/, '')}/?page=behaviors`;
 
-test('demo code blocks do not wrap/break tokens (editor style, horizontal scroll)', async ({ page }) => {
+test('NO demo code block wraps/breaks tokens (editor style, horizontal scroll)', async ({ page }) => {
   await page.goto(URL, { waitUntil: 'domcontentloaded' });
   await page.waitForSelector('#mainPage-behaviors', { timeout: 25000 });
-  await page.waitForTimeout(2800);
+  await page.waitForTimeout(3000);
 
-  const r = await page.evaluate(() => {
-    const pre = document.querySelector('pre.x-pre, .x-pre-wrapper pre, .wb-demo__code') as HTMLElement;
-    if (!pre) return null;
-    const cs = getComputedStyle(pre);
-    return { whiteSpace: cs.whiteSpace, overflowX: cs.overflowX, wordBreak: cs.wordBreak };
+  const blocks = await page.evaluate(() => {
+    const pres = [...document.querySelectorAll('pre.x-pre, .x-pre-wrapper pre, pre.wb-demo__code')];
+    return pres.map((p, i) => {
+      const cs = getComputedStyle(p as HTMLElement);
+      return { i, whiteSpace: cs.whiteSpace, overflowX: cs.overflowX, wordBreak: cs.wordBreak };
+    });
   });
 
-  expect(r, 'no demo code block found').not.toBeNull();
-  expect(r!.whiteSpace, `code wraps (white-space=${r!.whiteSpace}); should be pre`).toBe('pre');
-  expect(['auto', 'scroll'], `code does not scroll horizontally (overflow-x=${r!.overflowX})`).toContain(r!.overflowX);
-  expect(r!.wordBreak, `code breaks tokens (word-break=${r!.wordBreak})`).not.toBe('break-word');
+  expect(blocks.length, 'no code blocks found').toBeGreaterThan(3);
+  const wrappers = blocks.filter((b) => b.whiteSpace !== 'pre');
+  const breakers = blocks.filter((b) => b.wordBreak === 'break-word');
+  expect(
+    wrappers,
+    `${wrappers.length}/${blocks.length} code blocks still wrap (white-space != pre): ${JSON.stringify(wrappers.slice(0, 3))}`
+  ).toEqual([]);
+  expect(
+    breakers,
+    `${breakers.length}/${blocks.length} code blocks break tokens (word-break: break-word)`
+  ).toEqual([]);
 });

--- a/tests/behaviors/dark-mode-switch.spec.ts
+++ b/tests/behaviors/dark-mode-switch.spec.ts
@@ -1,0 +1,35 @@
+/**
+ * The Dark Mode switch (<wb-switch theme-control>) must drive the page theme:
+ * ON = dark, OFF = light. (#210)
+ */
+import { test, expect } from '@playwright/test';
+
+const BASE = process.env.WB_BASE || 'http://localhost:3000';
+const URL = `${BASE.replace(/\/$/, '')}/?page=behaviors`;
+
+test('Dark Mode switch toggles data-theme between dark and light', async ({ page }) => {
+  await page.goto(URL, { waitUntil: 'domcontentloaded' });
+  await page.waitForSelector('wb-switch[theme-control]', { timeout: 25000 });
+  await page.waitForTimeout(2000);
+
+  const r = await page.evaluate(async () => {
+    const root = document.documentElement;
+    root.setAttribute('data-theme', 'dark');
+    const sw = document.querySelector('wb-switch[theme-control]') as HTMLElement;
+    const inp = sw.querySelector('input') as HTMLInputElement;
+    // re-sync initial state to current theme
+    inp.checked = true;
+
+    const start = root.getAttribute('data-theme');
+    sw.click(); // -> off -> light
+    await new Promise((r) => setTimeout(r, 120));
+    const afterOff = root.getAttribute('data-theme');
+    sw.click(); // -> on -> dark
+    await new Promise((r) => setTimeout(r, 120));
+    const afterOn = root.getAttribute('data-theme');
+    return { start, afterOff, afterOn };
+  });
+
+  expect(r.afterOff, `turning Dark Mode OFF did not switch to light (got ${r.afterOff})`).toBe('light');
+  expect(r.afterOn, `turning Dark Mode ON did not switch to dark (got ${r.afterOn})`).toBe('dark');
+});


### PR DESCRIPTION
wb-switch theme-control drives data-theme (ON=dark, OFF=light); darkmode.js corrected to set data-theme not theme. dark-mode-switch.spec.ts passing. Closes #210