### PR TITLE
fix(#686,#687): behaviors browse panel — reveal on phones, align to top on arrows

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,15 +27,15 @@
   <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
 
   <!-- Layer 1: Foundation (render-blocking, already highest priority — no preload needed) -->
-  <link rel="stylesheet" href="src/styles/normalize.css?v=28fee16">
-  <link rel="stylesheet" href="src/styles/themes.css?v=28fee16">
-  <link rel="stylesheet" href="src/styles/site.css?v=28fee16">
-  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=28fee16">
-  <link rel="modulepreload" href="src/core/wb.js?v=28fee16">
-  <link rel="modulepreload" href="src/core/site-engine.js?v=28fee16">
+  <link rel="stylesheet" href="src/styles/normalize.css?v=fbbfc33">
+  <link rel="stylesheet" href="src/styles/themes.css?v=fbbfc33">
+  <link rel="stylesheet" href="src/styles/site.css?v=fbbfc33">
+  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=fbbfc33">
+  <link rel="modulepreload" href="src/core/wb.js?v=fbbfc33">
+  <link rel="modulepreload" href="src/core/site-engine.js?v=fbbfc33">
 
   <!-- Page Transitions CSS -->
-  <link rel="stylesheet" href="src/styles/transitions.css?v=28fee16">
+  <link rel="stylesheet" href="src/styles/transitions.css?v=fbbfc33">
   <!-- Navbar CSS already loads via site.css's own @import — no separate link needed. -->
 
   <!-- Fonts -->
@@ -92,9 +92,9 @@
   </template>
 
   <!-- Premium Navbar Scroll Effect -->
-  <script src="src/lib/premium-navbar.js?v=28fee16"></script>
+  <script src="src/lib/premium-navbar.js?v=fbbfc33"></script>
 
   <!-- Main Application Bootstrap -->
-  <script type="module" src="./src/main.js?v=28fee16"></script>
+  <script type="module" src="./src/main.js?v=fbbfc33"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wb-starter",
-  "version": "3.0.42",
+  "version": "3.0.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wb-starter",
-      "version": "3.0.42",
+      "version": "3.0.43",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wb-starter",
-  "version": "3.0.42",
+  "version": "3.0.43",
   "type": "module",
   "description": "Modern website starter kit powered by WB Behaviors",
   "main": "index.html",

--- a/pages/behaviors.html
+++ b/pages/behaviors.html
@@ -420,6 +420,11 @@
     // beside the list and upgrades it in place -- no scrolling a 13,000px page
     // to find the example.
     const liveEl = document.getElementById('behaviors-live');
+    // #686 -- must stay in sync with the `@media (max-width: 60rem)` rule in
+    // src/styles/pages/behaviors.css that collapses .behaviors-browse to one
+    // column. Below that width the panel stacks BELOW the results list rather
+    // than beside it, which is the only case where revealing it is correct.
+    const STACKED = matchMedia('(max-width: 60rem)');
     const liveToken = document.getElementById('behaviors-live-token');
     const liveNote = document.getElementById('behaviors-live-note');
     const liveStage = document.getElementById('behaviors-live-stage');
@@ -1278,7 +1283,7 @@
       return [...resultsEl.querySelectorAll('.behaviors-search-results__row')];
     }
 
-    function selectRow(row, { focus = true } = {}) {
+    function selectRow(row, { focus = true, reveal = false, align = false } = {}) {
       if (!row) return;
       rowsInOrder().forEach((r) => r.removeAttribute('aria-current'));
       row.setAttribute('aria-current', 'true');
@@ -1290,13 +1295,37 @@
       const listTop = resultsEl.scrollTop;
       const rowTop = row.offsetTop - resultsEl.offsetTop;
       const rowBottom = rowTop + row.offsetHeight;
-      if (rowTop < listTop) resultsEl.scrollTop = rowTop;
+      if (align) {
+        // #687 -- John: "I would like all down arrow activity to align with the
+        // top every time it's pressed". Minimal scrolling left the selection
+        // pinned to the BOTTOM edge once it got there, so arrowing read as "the
+        // list is stuck" even though the panel kept changing. Pinning the row to
+        // the top moves the list one row per press, and the browser clamps
+        // scrollTop at the end -- which is the "page to the next set of choices"
+        // John asked for as the last rows come into range.
+        resultsEl.scrollTop = rowTop;
+      } else if (rowTop < listTop) resultsEl.scrollTop = rowTop;
       else if (rowBottom > listTop + resultsEl.clientHeight) {
         resultsEl.scrollTop = rowBottom - resultsEl.clientHeight;
       }
       if (focus) row.focus({ preventScroll: true });
       showLive(row.dataset.browseToken, row.dataset.variant || '', row.dataset.label || '',
                row.dataset.prop || '', row.dataset.boolean === '1');
+      // #686 -- John, on a phone: "doesn't show the sample code and result".
+      // Stacked, the panel starts ~300px past the bottom of #siteBody (measured
+      // at 375x812: list ends at 841, panel stage at 920, scroller is 627 tall),
+      // so a tap rendered the demo somewhere the reader could not see with no
+      // cue anything had happened. Two columns keep the no-scroll rule above --
+      // there the panel is already beside the list. `reveal` is opt-in per call
+      // so the best-match selectRow() that applyFilter() runs on EVERY keystroke
+      // never yanks the page away from the search box.
+      // Instant, not smooth: showLive() injects the demo, fetches its doc and
+      // re-lays out the panel while the animation would still be running, and
+      // the browser cancels a smooth scroll on that churn -- measured landing
+      // back at scrollTop 0 every time.
+      if (reveal && STACKED.matches) {
+        liveEl.scrollIntoView({ block: 'start' });
+      }
     }
 
     function moveSelection(delta) {
@@ -1307,14 +1336,14 @@
       i = i < 0 ? (delta > 0 ? 0 : rows.length - 1) : i + delta;
       if (i < 0) i = 0;
       if (i > rows.length - 1) i = rows.length - 1;
-      selectRow(rows[i]);
+      selectRow(rows[i], { align: true });
     }
 
     resultsEl.addEventListener('keydown', (e) => {
       if (e.key === 'ArrowDown') { e.preventDefault(); moveSelection(1); }
       else if (e.key === 'ArrowUp') { e.preventDefault(); moveSelection(-1); }
-      else if (e.key === 'Home') { e.preventDefault(); selectRow(rowsInOrder()[0]); }
-      else if (e.key === 'End') { e.preventDefault(); const r = rowsInOrder(); selectRow(r[r.length - 1]); }
+      else if (e.key === 'Home') { e.preventDefault(); selectRow(rowsInOrder()[0], { align: true }); }
+      else if (e.key === 'End') { e.preventDefault(); const r = rowsInOrder(); selectRow(r[r.length - 1], { align: true }); }
     });
 
     // Down from the search box drops into the list, so the keyboard path works
@@ -1323,7 +1352,7 @@
       if (e.key === 'ArrowDown') {
         e.preventDefault();
         const rows = rowsInOrder();
-        if (rows.length) selectRow(rows[0]);
+        if (rows.length) selectRow(rows[0], { align: true });
       }
     });
 
@@ -1335,7 +1364,7 @@
         // re-run applyFilter and collapse the browse list to just this one
         // behavior, so picking the next one meant clearing the box first --
         // the list has to stay browsable while the panel changes beside it.
-        selectRow(btn, { focus: false });
+        selectRow(btn, { focus: false, reveal: true });
         return;
       }
       // #664: render it in the panel beside the list. Deliberately NO
@@ -1343,7 +1372,12 @@
       // show the code render in element next to dropdown". Jumping the page
       // away from the search box is the behaviour this panel replaces.
       const rowToken = btn.querySelector('.behaviors-search-results__token');
-      if (rowToken) showLive(rowToken.textContent.trim().split(/\s+/)[0], btn.dataset.variant || '');
+      if (rowToken) {
+        showLive(rowToken.textContent.trim().split(/\s+/)[0], btn.dataset.variant || '');
+        // #686: same reveal as the branch above -- stacked, the panel is below
+        // the fold and the render is invisible without it.
+        if (STACKED.matches) liveEl.scrollIntoView({ block: 'start' });
+      }
     });
 
     input.addEventListener('input', () => applyFilter(input.value));

--- a/project-index.html
+++ b/project-index.html
@@ -7,8 +7,8 @@
     <title>Project Index</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
-    <link rel="stylesheet" href="src/styles/themes.css?v=28fee16">
-    <link rel="stylesheet" href="src/styles/site.css?v=28fee16">
+    <link rel="stylesheet" href="src/styles/themes.css?v=fbbfc33">
+    <link rel="stylesheet" href="src/styles/site.css?v=fbbfc33">
     <script type="module">
       import WB from './src/core/wb.js';
       WB.init({ autoInject: true });

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -3,7 +3,7 @@
  * Regenerated on every commit via .husky/pre-commit.
  */
 export const VERSION = {
-  "version": "3.0.42",
-  "commit": "28fee16",
-  "builtAt": "2026-08-20T18:46:52.080Z"
+  "version": "3.0.43",
+  "commit": "fbbfc33",
+  "builtAt": "2026-08-20T20:03:42.876Z"
 };

--- a/tests/behaviors/behaviors-browse-navigation.spec.ts
+++ b/tests/behaviors/behaviors-browse-navigation.spec.ts
@@ -1,0 +1,164 @@
+/**
+ * Behaviors page browse panel — selection navigation.
+ *
+ * #686 — stacked (phone) layout: tapping a result must put the rendered demo
+ *        and its HTML sample in view. It used to render ~300px below the fold
+ *        with no cue anything had happened.
+ * #687 — arrow keys must pin the selected row to the TOP of the list, and the
+ *        end of the list must stay reachable.
+ *
+ * Both are about where things end up on screen, so every assertion here is a
+ * measured rect or scroll offset, never a visibility flag — the panel was
+ * always "visible" in the DOM sense while being completely off-screen.
+ */
+import { test, expect, Page } from '@playwright/test';
+
+const PHONE = { width: 375, height: 812 };
+
+async function loadBrowse(page: Page, query = 'x-tooltip') {
+  await page.goto('/?page=behaviors');
+  await page.waitForSelector('#behaviors-search', { timeout: 20000 });
+  await page.waitForFunction(
+    () => (document.querySelectorAll('.behaviors-search-results__row').length > 0),
+    { timeout: 20000 },
+  );
+  await page.fill('#behaviors-search', query);
+  await page.waitForFunction(
+    () => document.querySelectorAll('.behaviors-search-results__row').length > 0,
+    { timeout: 10000 },
+  );
+}
+
+test.describe('#686 — stacked layout reveals the demo when a result is tapped', () => {
+  test.use({ viewport: PHONE });
+
+  test('tapping a result brings the rendered demo and its HTML into view', async ({ page }) => {
+    await loadBrowse(page);
+
+    // The layout must actually be the stacked one, or this test proves nothing.
+    expect(await page.evaluate(() => matchMedia('(max-width: 60rem)').matches)).toBe(true);
+
+    await page.evaluate(() => { document.getElementById('siteBody')!.scrollTop = 0; });
+    await page.locator('.behaviors-search-results__row').first().click();
+    await page.waitForTimeout(400);
+
+    const seen = await page.evaluate(() => {
+      const inView = (el: Element | null) => {
+        if (!el) return false;
+        const b = el.getBoundingClientRect();
+        return b.top < window.innerHeight && b.bottom > 0 && b.height > 0;
+      };
+      return {
+        stage: inView(document.getElementById('behaviors-live-stage')),
+        code: inView(document.getElementById('behaviors-live-code')),
+        codeText: document.getElementById('behaviors-live-code')!.textContent || '',
+      };
+    });
+
+    expect(seen.stage, 'rendered demo must be on screen after a tap').toBe(true);
+    expect(seen.code, 'HTML sample must be on screen after a tap').toBe(true);
+    expect(seen.codeText).toContain('x-tooltip');
+  });
+
+  test('typing never moves the page away from the search box', async ({ page }) => {
+    await loadBrowse(page, '');
+    await page.evaluate(() => { document.getElementById('siteBody')!.scrollTop = 0; });
+    await page.type('#behaviors-search', 'x-tool', { delay: 40 });
+    await page.waitForTimeout(400);
+    const scrollTop = await page.evaluate(() => document.getElementById('siteBody')!.scrollTop);
+    expect(scrollTop, 'search must not scroll the page while the reader types').toBe(0);
+  });
+});
+
+test.describe('#686 — two-column layout still does not scroll', () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test('picking a result leaves the page where it was', async ({ page }) => {
+    await loadBrowse(page);
+    expect(await page.evaluate(() => matchMedia('(max-width: 60rem)').matches)).toBe(false);
+
+    await page.evaluate(() => { document.getElementById('siteBody')!.scrollTop = 0; });
+    await page.locator('.behaviors-search-results__row').first().click();
+    await page.waitForTimeout(400);
+
+    const scrollTop = await page.evaluate(() => document.getElementById('siteBody')!.scrollTop);
+    expect(scrollTop, 'side-by-side, the panel is already visible — nothing should move').toBe(0);
+  });
+});
+
+test.describe('#687 — arrow keys align the selection to the top of the list', () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test('each ArrowDown puts the selected row at the top of the list viewport', async ({ page }) => {
+    await loadBrowse(page, 'x-');
+
+    await page.locator('.behaviors-search-results__row').first().focus();
+
+    const offsets: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press('ArrowDown');
+      await page.waitForTimeout(120);
+      offsets.push(await page.evaluate(() => {
+        const list = document.getElementById('behaviors-search-results')!;
+        const cur = list.querySelector('[aria-current="true"]') as HTMLElement;
+        return Math.round((cur.offsetTop - list.offsetTop) - list.scrollTop);
+      }));
+    }
+
+    for (const [i, delta] of offsets.entries()) {
+      expect(Math.abs(delta), `press ${i + 1}: selected row sat ${delta}px from the top`).toBeLessThanOrEqual(2);
+    }
+  });
+
+  test('ArrowUp aligns to the top as well', async ({ page }) => {
+    await loadBrowse(page, 'x-');
+    await page.locator('.behaviors-search-results__row').first().focus();
+    for (let i = 0; i < 6; i++) { await page.keyboard.press('ArrowDown'); }
+    await page.waitForTimeout(150);
+    await page.keyboard.press('ArrowUp');
+    await page.waitForTimeout(150);
+
+    const delta = await page.evaluate(() => {
+      const list = document.getElementById('behaviors-search-results')!;
+      const cur = list.querySelector('[aria-current="true"]') as HTMLElement;
+      return Math.round((cur.offsetTop - list.offsetTop) - list.scrollTop);
+    });
+    expect(Math.abs(delta)).toBeLessThanOrEqual(2);
+  });
+
+  test('End reaches the last row and leaves it fully visible', async ({ page }) => {
+    await loadBrowse(page, 'x-');
+    await page.locator('.behaviors-search-results__row').first().focus();
+    await page.keyboard.press('End');
+    await page.waitForTimeout(250);
+
+    const end = await page.evaluate(() => {
+      const list = document.getElementById('behaviors-search-results')!;
+      const rows = [...list.querySelectorAll('.behaviors-search-results__row')];
+      const cur = list.querySelector('[aria-current="true"]') as HTMLElement;
+      const cb = cur.getBoundingClientRect(), lb = list.getBoundingClientRect();
+      return {
+        isLast: rows.indexOf(cur) === rows.length - 1,
+        atBottom: Math.abs((list.scrollHeight - list.clientHeight) - list.scrollTop) <= 2,
+        fullyVisible: cb.top >= lb.top - 2 && cb.bottom <= lb.bottom + 2,
+      };
+    });
+
+    expect(end.isLast, 'End must select the last row').toBe(true);
+    expect(end.atBottom, 'the list must page all the way to the end').toBe(true);
+    expect(end.fullyVisible, 'the last row must be fully in the list viewport').toBe(true);
+  });
+
+  test('clicking a row leaves the list scroll exactly where the reader put it', async ({ page }) => {
+    await loadBrowse(page, 'x-');
+    await page.evaluate(() => { document.getElementById('behaviors-search-results')!.scrollTop = 500; });
+    await page.waitForTimeout(80);
+
+    const rows = page.locator('.behaviors-search-results__row');
+    await rows.nth(12).click();
+    await page.waitForTimeout(300);
+
+    const after = await page.evaluate(() => document.getElementById('behaviors-search-results')!.scrollTop);
+    expect(Math.round(after), 'a click must not yank the list').toBe(500);
+  });
+});


### PR DESCRIPTION
## #686 — on a phone, tapping a behavior showed nothing

Measured at 375x812 before the fix:

| Element | Top (page px) |
|---|---|
| results list ends | 841 |
| `#behaviors-live` starts | 859 |
| rendered demo (`#behaviors-live-stage`) | 920 |
| HTML sample (`#behaviors-live-code`) | 1028 |

…inside `#siteBody`, a scroller **627px** tall. The demo was rendering 300–400px past the bottom of the visible area, so a tap looked inert.

Cause is two individually-correct decisions colliding:

1. `@media (max-width: 60rem)` in `src/styles/pages/behaviors.css` collapses `.behaviors-browse` to one column, stacking the panel **below** the full-height list.
2. `selectRow()` deliberately never scrolls — *"don't scroll down to existing samples, just show the code render in element next to dropdown"*. Right when the panel is beside the list; invisible when it's underneath it.

**Fix:** stacked layouts reveal the panel on an explicit pick. Two-column keeps the no-scroll rule exactly as it was. `reveal` is opt-in per call, so the best-match `selectRow()` that `applyFilter()` runs on **every keystroke** never yanks the page away from the search box.

The reveal is instant, not smooth — `showLive()` injects the demo and fetches its doc while a smooth scroll would still be animating, and the browser cancels the animation on that churn. Measured: it landed back at `scrollTop` 0 every time.

## #687 — arrow keys now align the selection to the top

> "I would like all down arrow activity to align with the top every time it's pressed. Also when the user gets towards the last selection, when moving to the last one, the items should all page to the next set of choices."

Minimal scrolling pinned the selection to the **bottom** edge once it got there, so arrowing read as a stuck list even though the panel kept changing. Arrow/Home/End now pin the selected row to the top of the list viewport, and `scrollTop` clamps at the end — which is the paging behaviour for the final rows.

Clicks and typing keep the old minimal-scroll path. Neither should move the list.

## Test plan

`tests/behaviors/behaviors-browse-navigation.spec.ts` — **7/7 passing**. Every assertion is a measured rect or scroll offset, never a visibility flag: the panel was always "visible" in the DOM sense while completely off-screen.

- [x] 375x812 — stage and code both on screen after a tap
- [x] 375x812 — typing never moves the page
- [x] 1280x900 — click leaves `#siteBody` scrollTop at 0
- [x] ArrowDown x5 — selected row sits 0px from the list top on every press
- [x] ArrowUp — same
- [x] End — selects the last row, list clamps to its end, row fully visible
- [x] click at list scrollTop 500 — leaves it at 500

## Compliance

`tests/compliance` — 7591 passed / **82 failed**, all pre-existing (the backlog John parked at ~70 in `73d5210`). **None are attributable to this change**: the two that name `pages/behaviors.html` are the `picsum.photos` absolute asset path (line 698 on `main`, untouched) and a redundant `x-` attribute; this diff adds zero lines matching `https?://` or an `x-*` attribute.

Closes #686
Closes #687