### PR TITLE
fix(#689,#690,#691): details gets a real summary; demos stop inheriting hero typography

### DIFF
--- a/src/core/version.js
+++ b/src/core/version.js
@@ -5,5 +5,5 @@
 export const VERSION = {
   "version": "3.0.43",
   "commit": "fbbfc33",
-  "builtAt": "2026-08-20T20:03:42.876Z"
+  "builtAt": "2026-08-20T20:15:12.664Z"
 };

--- a/src/styles/pages/behaviors.css
+++ b/src/styles/pages/behaviors.css
@@ -505,6 +505,26 @@ footer a:hover {
   text-align: left;
 }
 
+/* #690 -- the panel lives inside #behaviors-hero.page__hero, so site.css's hero
+   rules were styling whatever a DEMO renders: h1 at 3rem, and every <p> at
+   1.25rem, --text-muted, capped at 600px and auto-centred (measured 600px wide
+   with 32.5px side margins inside a 697px box -- the uneven gap in John's
+   screenshot). These restore site.css's OWN base values, so a demo renders the
+   way it would on any other page. The text-align above already stops the
+   inherited centring, and it stops at the stage root so a demo that centres its
+   own content still does. */
+.behaviors-live__stage h1 {
+  font-size: 2.5rem;
+  margin: 0 0 0.5rem;
+}
+
+.behaviors-live__stage p {
+  font-size: 1rem;
+  color: var(--text-secondary);
+  max-width: none;
+  margin: 0 0 1rem;
+}
+
 
 /* #666: two columns per row, variant FIRST so it reads down the left edge. */
 .behaviors-search-results__row {

--- a/src/wb-viewmodels/semantics/details.js
+++ b/src/wb-viewmodels/semantics/details.js
@@ -43,6 +43,30 @@ export function details(element, options = {}) {
   } else {
     element.classList.add('wb-details');
     if (config.open) element.open = true;
+
+    // #689 -- John: "the gaps here are not right". A native <details> authored
+    // with the summary as an ATTRIBUTE (<details summary="Trail conditions">)
+    // got neither a <summary> element nor a .wb-details__content wrapper, so
+    // the styling below -- which is what applies the 1rem to each half -- had
+    // nothing to find. The browser fell back to its own unpadded "Details"
+    // label (dropping the authored text entirely), the <img> sat flush against
+    // the 1px border, and a centred <p> kept its 48px auto margins: three
+    // different insets in one box. Build the same structure the wrap path
+    // above builds, so both paths end up styled identically.
+    const ownSummary = [...element.children].find((c) => c.tagName === 'SUMMARY');
+    if (!ownSummary) {
+      const content = document.createElement('div');
+      content.className = 'wb-details__content';
+      while (element.firstChild) content.appendChild(element.firstChild);
+
+      const summaryEl = document.createElement('summary');
+      summaryEl.className = 'wb-details__summary';
+      // textContent, not innerHTML: the attribute is author input and the
+      // label is plain text -- there is nothing here that needs markup.
+      summaryEl.textContent = element.getAttribute('summary') || 'Details';
+
+      element.append(summaryEl, content);
+    }
   }
 
   // Style the native element

--- a/tests/behaviors/details-summary-and-stage-typography.spec.ts
+++ b/tests/behaviors/details-summary-and-stage-typography.spec.ts
@@ -1,0 +1,118 @@
+/**
+ * #689 — a native <details> authored with `summary` as an ATTRIBUTE got no
+ *        <summary> element and no .wb-details__content wrapper, so the 1rem
+ *        padding never applied and the authored label never rendered.
+ * #690 — the behaviors browse panel sits inside .page__hero, so site.css's hero
+ *        rules styled whatever a DEMO rendered: <p> at 1.25rem, muted, capped
+ *        at 600px and auto-centred.
+ *
+ * Both showed up as "the gaps here are not right": summary flush in the corner,
+ * image at the border, paragraph inset 48px — three insets in one box.
+ */
+import { test, expect, Page } from '@playwright/test';
+
+async function showDetailsDemo(page: Page) {
+  await page.goto('/?page=behaviors');
+  await page.waitForSelector('#behaviors-search', { timeout: 20000 });
+  await page.fill('#behaviors-search', 'x-');
+  await page.waitForFunction(
+    () => document.querySelectorAll('.behaviors-search-results__row').length > 0,
+    { timeout: 20000 },
+  );
+  await page.evaluate(() => {
+    const row = [...document.querySelectorAll('.behaviors-search-results__row')]
+      .find((r) => r.getAttribute('data-browse-token') === 'x-details'
+                && r.getAttribute('data-variant') === 'true') as HTMLElement;
+    if (!row) throw new Error('x-details/true row not found in the browse list');
+    row.click();
+  });
+  await page.waitForSelector('#behaviors-live-stage details', { timeout: 10000 });
+  await page.waitForTimeout(400);
+}
+
+test.describe('#689 — native <details> gets a summary element and a content wrapper', () => {
+  test('the authored summary attribute renders as the label', async ({ page }) => {
+    await showDetailsDemo(page);
+    const label = await page.evaluate(() => {
+      const sum = document.querySelector('#behaviors-live-stage details summary');
+      return sum ? sum.textContent!.replace(/\s+/g, ' ').trim() : null;
+    });
+    expect(label, 'a <summary> element must exist').not.toBeNull();
+    expect(label, 'must show the authored text, not the UA "Details" fallback').toContain('Trail conditions');
+  });
+
+  test('summary and content share one inset, and the image sits on it', async ({ page }) => {
+    await showDetailsDemo(page);
+    const geo = await page.evaluate(() => {
+      const det = document.querySelector('#behaviors-live-stage details') as HTMLElement;
+      const sum = det.querySelector('summary') as HTMLElement;
+      const content = det.querySelector('.wb-details__content') as HTMLElement;
+      const img = det.querySelector('img') as HTMLElement;
+      const p = det.querySelector('p') as HTMLElement;
+      const left = (el: HTMLElement) => Math.round(el.getBoundingClientRect().left);
+      return {
+        hasContent: !!content,
+        summaryPad: getComputedStyle(sum).padding,
+        contentPad: content ? getComputedStyle(content).padding : null,
+        imgLeft: img ? left(img) : null,
+        pLeft: p ? left(p) : null,
+      };
+    });
+
+    expect(geo.hasContent, 'children must be wrapped in .wb-details__content').toBe(true);
+    expect(geo.summaryPad, 'summary keeps the 1rem the styling code applies').toBe('16px');
+    expect(geo.contentPad, 'content gets the same 1rem').toBe('16px');
+    expect(geo.imgLeft, 'image and paragraph must sit on the same inset').toBe(geo.pLeft);
+  });
+
+  test('a <details> that brings its own <summary> is left alone', async ({ page }) => {
+    await page.goto('/?page=behaviors');
+    await page.waitForSelector('#behaviors-search', { timeout: 20000 });
+
+    const result = await page.evaluate(async () => {
+      const mod: any = await import('/src/wb-viewmodels/semantics/details.js');
+      const host = document.createElement('div');
+      host.innerHTML = '<details summary="Ignored"><summary>Mine</summary><p>body</p></details>';
+      document.body.appendChild(host);
+      const det = host.querySelector('details') as HTMLElement;
+      mod.details(det, {});
+      const summaries = det.querySelectorAll('summary');
+      const label = summaries[0].textContent!.replace(/\s+/g, ' ').trim();
+      host.remove();
+      return { count: summaries.length, label };
+    });
+
+    expect(result.count, 'must not add a second <summary>').toBe(1);
+    expect(result.label, "the element's own summary wins over the attribute").toContain('Mine');
+  });
+});
+
+test.describe('#690 — demo output does not inherit hero typography', () => {
+  test('a demo paragraph is not capped, centred, or muted by the hero rule', async ({ page }) => {
+    await showDetailsDemo(page);
+    const p = await page.evaluate(() => {
+      const el = document.querySelector('#behaviors-live-stage details p') as HTMLElement;
+      const cs = getComputedStyle(el);
+      return { fontSize: cs.fontSize, maxWidth: cs.maxWidth, marginLeft: cs.marginLeft, marginRight: cs.marginRight };
+    });
+
+    expect(p.fontSize, 'hero subtitle size (1.25rem/20px) must not reach a demo').toBe('16px');
+    expect(p.maxWidth, 'the hero 600px cap must not reach a demo').toBe('none');
+    expect(p.marginLeft, 'no auto-centring inside a demo').toBe('0px');
+    expect(p.marginRight, 'no auto-centring inside a demo').toBe('0px');
+  });
+
+  test('a demo heading uses the site h1 size, not the hero 3rem', async ({ page }) => {
+    await showDetailsDemo(page);
+    const size = await page.evaluate(() => {
+      const stage = document.getElementById('behaviors-live-stage')!;
+      const h1 = document.createElement('h1');
+      h1.textContent = 'probe';
+      stage.appendChild(h1);
+      const fs = getComputedStyle(h1).fontSize;
+      h1.remove();
+      return fs;
+    });
+    expect(size, 'hero h1 (3rem/48px) must not reach a demo').toBe('40px');
+  });
+});

--- a/tests/behaviors/details-summary.spec.ts
+++ b/tests/behaviors/details-summary.spec.ts
@@ -6,7 +6,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #691: NOT WBSite. /demos/test-harness.html is a standalone page, not an SPA
+  // route, so window.WBSite is never created there -- waiting on it timed out at
+  // 20s and these assertions never ran. WB.behaviors is the readiness signal
+  // that actually applies, and setup() calls WB.scan() itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'details-test-area';


### PR DESCRIPTION
> John, on the behaviors panel showing `details · open`: **"the gaps here are not right"**

Three different insets were stacked in one box. Measured before:

| Element | inset from the details border |
|---|---|
| UA-default "▾ Details" line | **0** |
| `img.wb-img` | **1px** (just the border) |
| `p` | **48.5px** (auto side margins) |

Two independent causes, plus a red test that was hiding in the same area.

## #689 — the native `<details>` path built neither a summary nor a content wrapper

`src/wb-viewmodels/semantics/details.js` has two paths. The **wrap** path (element is not a `<details>`) builds `<summary>` + `.wb-details__content`, and the styling code below gives both `padding: 1rem`.

The **native** path — the demo's case, `<details open summary="Trail conditions"><img><p>…</p></details>` — did neither:

```js
const summary = element.querySelector('summary');   // null — `summary` is an ATTRIBUTE here
if (summary) { …padding: 1rem… }

const content = element.querySelector('.wb-details__content')
             || element.querySelector('summary + *');   // also null
if (content) { …padding: 1rem… }
```

So the browser fell back to its own unpadded "Details" label — **the authored text "Trail conditions" never rendered at all** — and nothing got padded.

The native path now builds the same structure the wrap path does; the existing styling code handles both identically. A `<details>` that brings its own `<summary>` is left alone (checked against direct children, and covered by a test).

## #690 — demos inherited page-hero typography

The panel lives inside `#behaviors-hero.page__hero`, so `site.css`'s hero rules styled whatever a **demo** rendered:

| Hero rule | Effect on demo output |
|---|---|
| `.page__hero h1 { font-size: 3rem }` | a demo `<h1>` at 3rem instead of the site's 2.5rem |
| `.page__hero p { 1.25rem; --text-muted; max-width: 600px; margin: 0 auto }` | a demo `<p>` oversized, greyed, capped and **auto-centred** — 600px wide with 32.5px side margins inside a 697px box |

`.behaviors-live__doc-body * { text-align: left }` already existed to undo the same centring for the docs body; the demo stage never got the equivalent. The added rules restore `site.css`'s **own** base values, so a demo renders the way it would on any other page.

Left for John's call, noted in #690: `.page__hero p` is really the hero *subtitle* rule (the markup already has `p.header-subtitle`) — retargeting it would fix this class of leak site-wide, but it touches every page's hero.

## #691 — 2 tests in `details-summary.spec.ts` were already red on `main`

Verified by stashing every local change and re-running: 1 passed / 2 failed, identical. **The product was fine** — reproduced by hand on the harness and got exactly what the tests assert.

`setup()` waited on `window.WBSite && WBSite.currentPage` after loading `/demos/test-harness.html`. That page is standalone, not an SPA route, so `WBSite` is never created (measured: `typeof window.WBSite === "undefined"`, while `WB.behaviors` is present). The wait timed out at 20s and the assertions never ran. The file's third test passes because it loads `/?page=components`, a real SPA route.

Wait removed. `WB.behaviors` is the signal that applies there, and `setup()` calls `WB.scan()` itself.

## After

| Element | inset |
|---|---|
| summary — reads **"Trail conditions ▼"** | 1rem |
| `.wb-details__content` | 1rem |
| `img` | on the 1rem inset |
| `p` | **same** 1rem inset, 16px, `--text-secondary`, uncapped |

## Test plan

- [x] `details` filter — **8/8 passing** (was 6 passed, 2 failed)
- [x] New `tests/behaviors/details-summary-and-stage-typography.spec.ts` — **5/5**
  - authored `summary` attribute renders as the label
  - summary and content share one inset; image and paragraph land on the same left edge
  - a `<details>` with its own `<summary>` gets no second one, and its own label wins
  - demo `<p>` is 16px, uncapped, not auto-centred
  - demo `<h1>` is 40px (site 2.5rem), not the hero's 48px

Closes #689
Closes #690
Closes #691