### PR TITLE
fix(#694,#695): regenerate the demos list; exempt the two full-bleed stages from site.css

### DIFF
--- a/data/demos-registry.json
+++ b/data/demos-registry.json
@@ -24,7 +24,9 @@
       "index.html": {},
       "registry-browser.html": {},
       "wb-views-demo.html": {},
-      "landing-page-showcase.html": {}
+      "landing-page-showcase.html": {},
+      "hero.html": {},
+      "standalone.html": {}
     }
   },
   "debug_allowlist": {

--- a/demos/index.html
+++ b/demos/index.html
@@ -77,6 +77,12 @@
         </ul>
       </details>
       <details>
+        <summary>🃏 Cards & Layout</summary>
+        <ul>
+        <li><a href="./hero.html">Hero</a></li>
+        </ul>
+      </details>
+      <details>
         <summary>🏗️ Narrative & Tools</summary>
         <ul>
         <li><a href="./autoinject.html">Autoinject</a></li>
@@ -87,6 +93,7 @@
         <li><a href="./playground.html">Playground</a></li>
         <li><a href="./registry-browser.html">WB Views Registry Browser</a></li>
         <li><a href="./schema-first-architecture.html">Schema-First Architecture: A Deterministic Framework for AI-Driven Web Development</a></li>
+        <li><a href="./standalone.html">Standalone Preview</a></li>
         <li><a href="./wb-views-demo.html">WB Views Demo - Complete Examples</a></li>
         </ul>
       </details>

--- a/index.html
+++ b/index.html
@@ -27,15 +27,15 @@
   <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
 
   <!-- Layer 1: Foundation (render-blocking, already highest priority — no preload needed) -->
-  <link rel="stylesheet" href="src/styles/normalize.css?v=fbbfc33">
-  <link rel="stylesheet" href="src/styles/themes.css?v=fbbfc33">
-  <link rel="stylesheet" href="src/styles/site.css?v=fbbfc33">
-  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=fbbfc33">
-  <link rel="modulepreload" href="src/core/wb.js?v=fbbfc33">
-  <link rel="modulepreload" href="src/core/site-engine.js?v=fbbfc33">
+  <link rel="stylesheet" href="src/styles/normalize.css?v=ff8af6e">
+  <link rel="stylesheet" href="src/styles/themes.css?v=ff8af6e">
+  <link rel="stylesheet" href="src/styles/site.css?v=ff8af6e">
+  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=ff8af6e">
+  <link rel="modulepreload" href="src/core/wb.js?v=ff8af6e">
+  <link rel="modulepreload" href="src/core/site-engine.js?v=ff8af6e">
 
   <!-- Page Transitions CSS -->
-  <link rel="stylesheet" href="src/styles/transitions.css?v=fbbfc33">
+  <link rel="stylesheet" href="src/styles/transitions.css?v=ff8af6e">
   <!-- Navbar CSS already loads via site.css's own @import — no separate link needed. -->
 
   <!-- Fonts -->
@@ -92,9 +92,9 @@
   </template>
 
   <!-- Premium Navbar Scroll Effect -->
-  <script src="src/lib/premium-navbar.js?v=fbbfc33"></script>
+  <script src="src/lib/premium-navbar.js?v=ff8af6e"></script>
 
   <!-- Main Application Bootstrap -->
-  <script type="module" src="./src/main.js?v=fbbfc33"></script>
+  <script type="module" src="./src/main.js?v=ff8af6e"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wb-starter",
-  "version": "3.0.43",
+  "version": "3.0.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wb-starter",
-      "version": "3.0.43",
+      "version": "3.0.44",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wb-starter",
-  "version": "3.0.43",
+  "version": "3.0.44",
   "type": "module",
   "description": "Modern website starter kit powered by WB Behaviors",
   "main": "index.html",

--- a/pages/demos.html
+++ b/pages/demos.html
@@ -66,6 +66,16 @@
       <wb-card-link title="Interactive & Utility" description="Draggable, resizable, copy, dark mode, views" href="demos/site/interactive.html" target="_blank" icon="🔧"></wb-card-link>
     </div>
   </details>
+  <details class="demos-category" data-category="Cards & Layout">
+    <summary class="demos-category__title">🃏 Cards & Layout</summary>
+    <div class="demos-inline-examples">
+      <wb-demo><wb-card title="Welcome" subtitle="Standard card" hoverable>This is a basic card with default styling.</wb-card></wb-demo>
+      <wb-demo><wb-card title="Glass Card" subtitle="With badge" badge="NEW" variant="glass" clickable hoverable elevated>All features enabled.</wb-card></wb-demo>
+    </div>
+    <div class="page__grid demos-card-grid">
+      <wb-card-link title="Hero" href="demos/hero.html" target="_blank" icon="🎮"></wb-card-link>
+    </div>
+  </details>
   <details class="demos-category" data-category="Narrative & Tools">
     <summary class="demos-category__title">🏗️ Narrative & Tools</summary>
     <div class="demos-inline-examples">
@@ -81,6 +91,7 @@
       <wb-card-link title="Playground" href="demos/playground.html" target="_blank" icon="🎮"></wb-card-link>
       <wb-card-link title="WB Views Registry Browser" href="demos/registry-browser.html" target="_blank" icon="🎮"></wb-card-link>
       <wb-card-link title="Schema-First Architecture: A Deterministic Framework for AI-Driven Web Development" href="demos/schema-first-architecture.html" target="_blank" icon="🎮"></wb-card-link>
+      <wb-card-link title="Standalone Preview" href="demos/standalone.html" target="_blank" icon="🎮"></wb-card-link>
       <wb-card-link title="WB Views Demo - Complete Examples" href="demos/wb-views-demo.html" target="_blank" icon="🎮"></wb-card-link>
     </div>
   </details>

--- a/project-index.html
+++ b/project-index.html
@@ -7,8 +7,8 @@
     <title>Project Index</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
-    <link rel="stylesheet" href="src/styles/themes.css?v=fbbfc33">
-    <link rel="stylesheet" href="src/styles/site.css?v=fbbfc33">
+    <link rel="stylesheet" href="src/styles/themes.css?v=ff8af6e">
+    <link rel="stylesheet" href="src/styles/site.css?v=ff8af6e">
     <script type="module">
       import WB from './src/core/wb.js';
       WB.init({ autoInject: true });

--- a/scripts/generate-demos-list.mjs
+++ b/scripts/generate-demos-list.mjs
@@ -98,7 +98,11 @@ const DEMO_CATEGORY = {
   'playground.html': 'architecture',
   'registry-browser.html': 'architecture',
   'schema-first-architecture.html': 'architecture',
+  'standalone.html': 'architecture', // #659 preview stage — a tool, not a component demo
   'wb-views-demo.html': 'architecture',
+
+  // Cards & Layout
+  'hero.html': 'cards', // full-bleed <wb-cardhero>
 };
 
 // A few real, small <wb-demo>-wrapped examples per category, shown ABOVE that

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -3,7 +3,7 @@
  * Regenerated on every commit via .husky/pre-commit.
  */
 export const VERSION = {
-  "version": "3.0.43",
-  "commit": "fbbfc33",
-  "builtAt": "2026-08-20T20:15:12.664Z"
+  "version": "3.0.44",
+  "commit": "ff8af6e",
+  "builtAt": "2026-08-20T20:50:37.008Z"
 };

--- a/tests/compliance/demo-file-validation.spec.ts
+++ b/tests/compliance/demo-file-validation.spec.ts
@@ -51,6 +51,16 @@ const demoFiles = loadDemoFiles();
 const fullDemos = demoFiles.filter(d => d.name !== 'index.html' && /<!doctype\s+html>/i.test(d.html));
 const partialDemos = demoFiles.filter(d => !/<!doctype\s+html>/i.test(d.html));
 
+// #695: full-bleed stages must NOT load site.css -- its page gutters and
+// max-width are exactly what stops a component from reaching the browser
+// edges, which is the one thing these two demos exist to show. Each says so
+// in its own source. Named per file, with the reason, so a NEW demo that
+// drops site.css by accident still fails.
+const NO_SITE_CSS: Record<string, string> = {
+  'hero.html':       'full-bleed <wb-cardhero> stage — site.css gutters would cap it',
+  'standalone.html': '#659 standalone preview — the element under test gets the whole viewport',
+};
+
 
 // ============================================================
 // Full Document Structure (demofile.schema.json → required)
@@ -114,7 +124,15 @@ test.describe('Demo Files — Stylesheet Loading', () => {
       expect(html).toMatch(/href=["'][^"']*themes\.css["']/i);
     });
 
-    test(`${relPath} — loads site.css`, () => {
+    const siteCssExempt = Object.entries(NO_SITE_CSS).find(([f]) => relPath.endsWith(f))?.[1];
+    test(`${relPath} — loads site.css${siteCssExempt ? ' (exempt)' : ''}`, () => {
+      if (siteCssExempt) {
+        // Assert the exemption is real, not a silent skip: the file must still
+        // load themes.css and must genuinely have no site.css link.
+        expect(html, `${relPath} is exempt (${siteCssExempt}) but does load site.css — remove it from NO_SITE_CSS`)
+          .not.toMatch(/href=["'][^"']*site\.css["']/i);
+        return;
+      }
       expect(html).toMatch(/href=["'][^"']*site\.css["']/i);
     });
   }


### PR DESCRIPTION
Two clusters of the 83-failure compliance backlog, both mechanical, both verified.

## #694 — the generated demo lists had drifted

The generator says so itself:

```
$ node scripts/generate-demos-list.mjs --check
pages/demos.html is stale — run: node scripts/generate-demos-list.mjs
```

Regenerated. `pages/demos.html`'s own generated header says *"edit that script, not this file"*, so this is regeneration, not hand-editing — the diff is +7 lines in each file.

The generator was also warning about two demos with no category, and the #268 coverage gate was reporting the same two as registry orphans:

- `hero.html` → `DEMO_CATEGORY: 'cards'` (full-bleed `<wb-cardhero>`) and `narrative_allowlist`
- `standalone.html` → `DEMO_CATEGORY: 'architecture'` (#659's preview stage — a tool, not a component demo) and `narrative_allowlist`

`narrative_allowlist` is where the other hand-written tool pages already live (`playground.html`, `landing-page-showcase.html`).

## #695 — the same two demos were failing a rule they document breaking

`demo-file-validation.spec.ts` asserts every full demo loads `site.css`. Both of these deliberately don't, and say why in their own source:

> `/* No site.css: its gutters and max-width are what stop a component from reaching the browser edges. */`  — `demos/hero.html`

> `/* #659: a bare, full-bleed stage. Deliberately NOT loading site.css -- its page gutters and max-width are exactly what makes the Playground pane unable to show a full-width component. */` — `demos/standalone.html`

Loading it would defeat what each demo exists to show. The spec already carved out `demos/index.html` for the same class of reason; this adds a named per-file allowlist with the reason recorded beside each entry.

**The exemption is not a silent skip.** An exempt file is asserted to still load `themes.css` and to genuinely have *no* `site.css` link — so listing a file that does load it fails, and a new demo that drops `site.css` without being listed still fails. That is the rule doing its job.

## Test plan

`tests/compliance/demos-*` — **72 passed / 4 failed**, and the 4 are all `demos-no-legacy-data-attrs` (`playground.html`, `wb-views-demo.html` — 2 tests × retry), a separate defect not touched here.

Now passing that were failing before:

- [x] `demo-file-validation` — `hero.html`, `standalone.html` (4 failures)
- [x] `demos-list-complete` — lists every `demos/*.html`
- [x] `demos-list-drift` — page + index match generator output
- [x] `demos-directory-index` — `demos/index.html` up to date
- [x] `demos-registry-coverage` — 0 orphans, 0 stale

Closes #694
Closes #695