### PR TITLE
fix(#697): wb-fieldset/wb-formrow accept the plain attribute, not just data-*

### DIFF
--- a/demos/playground.html
+++ b/demos/playground.html
@@ -471,7 +471,7 @@
     </wb-demo>
 
     <wb-demo>
-      <wb-formrow data-inline>
+      <wb-formrow inline>
         <input type="text" placeholder="City">
         <input type="text" placeholder="ZIP code">
       </wb-formrow>
@@ -482,14 +482,14 @@
     </wb-demo>
 
     <wb-demo>
-      <wb-fieldset data-collapsible>
+      <wb-fieldset collapsible>
         <legend>Advanced options</legend>
         <p>Retry attempts, timeout thresholds, and other rarely-changed settings live here.</p>
       </wb-fieldset>
     </wb-demo>
 
     <wb-demo events="wb:stepper:change">
-      <div x-stepper data-value="2" data-min="0" data-max="10"></div>
+      <div x-stepper value="2" min="0" max="10"></div>
     </wb-demo>
 
   </section>

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -5,5 +5,5 @@
 export const VERSION = {
   "version": "3.0.44",
   "commit": "ff8af6e",
-  "builtAt": "2026-08-20T20:50:37.008Z"
+  "builtAt": "2026-08-20T20:55:06.439Z"
 };

--- a/src/wb-viewmodels/enhancements.js
+++ b/src/wb-viewmodels/enhancements.js
@@ -59,7 +59,10 @@ export function form(element, options = {}) {
  */
 export function fieldset(element, options = {}) {
   const config = {
-    collapsible: options.collapsible ?? element.hasAttribute('data-collapsible'),
+    // #697: the plain attribute is the v3 form (TIER1-LAWS 11). data-collapsible
+    // is kept as a fallback so markup already authored against it keeps working.
+    collapsible: options.collapsible
+      ?? (element.hasAttribute('collapsible') || element.hasAttribute('data-collapsible')),
     collapsed: options.collapsed ?? element.hasAttribute('data-collapsed'),
     ...options
   };
@@ -135,7 +138,9 @@ export function inputgroup(element, options = {}) {
  */
 export function formrow(element, options = {}) {
   const config = {
-    inline: options.inline ?? element.hasAttribute('data-inline'),
+    // #697: plain attribute first, data-inline kept as a fallback.
+    inline: options.inline
+      ?? (element.hasAttribute('inline') || element.hasAttribute('data-inline')),
     ...options
   };
 

--- a/tests/compliance/demos-no-legacy-data-attrs.spec.ts
+++ b/tests/compliance/demos-no-legacy-data-attrs.spec.ts
@@ -40,7 +40,13 @@ const ALLOWED = new Set<string>(['data-theme', 'data-code-width', 'data-wb-expec
 //     table label (`content: attr(data-label)`), never read by any WB
 //     behavior -- unrelated to the deprecated-config-syntax this gate
 //     exists to catch.
-const EXCLUDE = new Set<string>(['legacy-syntax-check.html', 'wizard.html', 'registry-browser.html']);
+//   - wb-views-demo.html: data-wbv-for / data-wbv-template / data-wbv-no-autocode
+//     are read by that page's OWN vanilla script (details.dataset.wbvTemplate,
+//     details.dataset.wbvFor, hasAttribute('data-wbv-no-autocode')) on plain
+//     <details> / <example-block> elements. No WB behavior reads them, so they
+//     teach nobody deprecated WB config syntax -- same category as wizard.html's
+//     data-tab and registry-browser.html's data-label (#697).
+const EXCLUDE = new Set<string>(['legacy-syntax-check.html', 'wizard.html', 'registry-browser.html', 'wb-views-demo.html']);
 const SKIP_DIRS = new Set(['node_modules', '.git', 'data', 'test-results', '.playwright-artifacts', 'coverage', 'dist', 'out']);
 
 function walk(dir: string, out: string[]): void {


### PR DESCRIPTION
## The demo markup was the symptom; the behaviors were the bug

`demos-no-legacy-data-attrs` flagged `demos/playground.html`:

```html
<wb-fieldset data-collapsible>
<wb-formrow data-inline>
<div x-stepper data-value="2" data-min="0" data-max="10"></div>
```

Changing the markup alone would have **broken two of the three**, because `src/wb-viewmodels/enhancements.js` read only the `data-` form:

```js
collapsible: options.collapsible ?? element.hasAttribute('data-collapsible'),
inline:      options.inline      ?? element.hasAttribute('data-inline'),
```

There was no `getAttribute('collapsible')` path at all — so `<wb-fieldset collapsible>`, the form TIER1-LAWS §11 requires, silently did nothing. Both now read the plain attribute first and keep `data-` as a fallback, so nothing already authored breaks. `x-stepper` already preferred `getAttribute()`, so only its markup changed.

`wb-views-demo.html` joins `EXCLUDE` with the reason recorded beside the existing entries: its `data-wbv-for` / `data-wbv-template` / `data-wbv-no-autocode` are read by that page's **own vanilla script** (`details.dataset.wbvTemplate`, `hasAttribute('data-wbv-no-autocode')`) on plain `<details>` / `<example-block>` elements, never by a WB behavior — same category as `wizard.html`'s `data-tab` and `registry-browser.html`'s `data-label`.

## Test plan

- [x] `demos-no-legacy-data-attrs` — **54/54** (was 50/54)
- [x] Verified live that the plain attributes actually work:
  - `<wb-formrow inline>` → `class="wb-form-row wb-form-row--inline"`
  - `<fieldset collapsible>` → legend gets `wb-fieldset__legend--collapsible`
  - `<div x-stepper value="2" min="0" max="10">` renders and holds 2
- [x] Playground's own JS still runs — 0 page errors. `28fee16` reverted a reformatting that broke it, so this is attribute edits only, no reflow.

## Worth knowing

The live check needed a cache-busted import. `/src/*.js` is served with `?v=<commit>`, so an **uncommitted** edit to a behavior module keeps serving the cached copy — the page looks unfixed until you commit. Same class of thing as the service worker (`wb-cache-v2`) that made the #686 fix look inert earlier today.

Closes #697