### PR TITLE
fix(#699): the token column stays on one line and stops at its own edge

### DIFF
--- a/pages/behaviors.html
+++ b/pages/behaviors.html
@@ -352,6 +352,9 @@
           const t = document.createElement('span');
           t.className = 'behaviors-search-results__token';
           t.textContent = entry.label;
+          // #699: the token never wraps, so a long one (input[type="checkbox"])
+          // truncates with an ellipsis. Keep the full value reachable.
+          t.title = entry.label;
           const v = document.createElement('span');
           v.className = 'behaviors-search-results__variant';
           v.textContent = shownOption;

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -5,5 +5,5 @@
 export const VERSION = {
   "version": "3.0.44",
   "commit": "ff8af6e",
-  "builtAt": "2026-08-20T20:55:06.439Z"
+  "builtAt": "2026-08-20T20:59:41.190Z"
 };

--- a/src/styles/pages/behaviors.css
+++ b/src/styles/pages/behaviors.css
@@ -109,6 +109,15 @@
   font-family: var(--font-mono, monospace);
   color: var(--warning-color);
   font-size: 0.9rem;
+  /* #699 -- John: "these columns are not properly spaced", then on the wrapped
+     version: "don't wrap this text." A token like input[type="checkbox"] is one
+     unbroken string, so with nothing to stop it it painted across the gap into
+     the variant column. It is code (Standard 6: code never wraps), so it stays
+     on ONE line and truncates with an ellipsis when the column cannot hold it.
+     The full value is on the row's title attribute and in the panel header. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .behaviors-search-results__heading {

--- a/tests/behaviors/behaviors-browse-navigation.spec.ts
+++ b/tests/behaviors/behaviors-browse-navigation.spec.ts
@@ -162,3 +162,62 @@ test.describe('#687 — arrow keys align the selection to the top of the list', 
     expect(Math.round(after), 'a click must not yank the list').toBe(500);
   });
 });
+
+test.describe('#699 — the token column never wraps and never crosses the variant column', () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test('a long token stays on one line and stops before the variant', async ({ page }) => {
+    await loadBrowse(page, 'checkbox');
+
+    // input[type="checkbox"] is the longest token in the registry and is one
+    // unbroken string -- the exact case that painted over the variant column.
+    const geo = await page.evaluate(() => {
+      const tokens = [...document.querySelectorAll('.behaviors-search-results__token')] as HTMLElement[];
+      const t = tokens[0];
+      const v = t.parentElement!.querySelector('.behaviors-search-results__variant') as HTMLElement;
+      const cs = getComputedStyle(t);
+      const lh = parseFloat(cs.lineHeight) || 16;
+      const tb = t.getBoundingClientRect(), vb = v.getBoundingClientRect();
+      return {
+        text: t.textContent || '',
+        whiteSpace: cs.whiteSpace,
+        lines: Math.round(tb.height / lh),
+        gapToVariant: Math.round(vb.left - tb.right),
+        title: t.title,
+      };
+    });
+
+    expect(geo.text, 'expected the checkbox token').toContain('checkbox');
+    expect(geo.whiteSpace, 'the token is code — it must not wrap (Standard §6)').toBe('nowrap');
+    expect(geo.lines, 'the token must render on exactly one line').toBe(1);
+    expect(geo.gapToVariant, 'the token must stop before the variant column, not paint into it')
+      .toBeGreaterThanOrEqual(0);
+    expect(geo.title, 'a truncated token must still be readable via its title').toContain('checkbox');
+  });
+
+  test('forced past its column width it truncates — it does not wrap or overlap', async ({ page }) => {
+    await loadBrowse(page, 'checkbox');
+
+    const geo = await page.evaluate(async () => {
+      const tokens = [...document.querySelectorAll('.behaviors-search-results__token')] as HTMLElement[];
+      // Force the overflow condition a zoomed-in browser produces.
+      tokens.forEach((e) => { e.style.fontSize = '2.4rem'; });
+      await new Promise((r) => setTimeout(r, 150));
+      const t = tokens[0];
+      const v = t.parentElement!.querySelector('.behaviors-search-results__variant') as HTMLElement;
+      const lh = parseFloat(getComputedStyle(t).lineHeight) || 16;
+      const tb = t.getBoundingClientRect(), vb = v.getBoundingClientRect();
+      const out = {
+        lines: Math.round(tb.height / lh),
+        gapToVariant: Math.round(vb.left - tb.right),
+        truncated: t.scrollWidth > t.clientWidth + 1,
+      };
+      tokens.forEach((e) => { e.style.fontSize = ''; });
+      return out;
+    });
+
+    expect(geo.lines, 'still one line when the text no longer fits').toBe(1);
+    expect(geo.gapToVariant, 'still no overlap with the variant column').toBeGreaterThanOrEqual(0);
+    expect(geo.truncated, 'the overflow is absorbed by the ellipsis, not by spilling').toBe(true);
+  });
+});


### PR DESCRIPTION
> **John:** "these columns are not properly spaced" → rows rendering as `input[type="checkbox"primary`
> **John, on the first attempt (which wrapped it):** "don't wrap this text."

## What was happening

`input[type="checkbox"]` is one unbroken string with no natural break opportunity. The row is a grid:

```css
.behaviors-search-results__row { grid-template-columns: minmax(0, 1fr) 7rem; gap: 0.5rem; }
.behaviors-search-results__variant { … overflow-wrap: anywhere; }
```

The **variant** cell was given a break rule. The **token** cell never was — so `minmax(0, 1fr)` shrank the column and the text simply overflowed it and painted across the gap into the variant.

## The fix

Not wrapping — the token is code, and **Standard §6 is that code never wraps**. It stays on one line and truncates with an ellipsis when the column can't hold it, which is also what keeps the two columns reading as columns down the list.

```css
white-space: nowrap;
overflow: hidden;
text-overflow: ellipsis;
```

Truncation doesn't lose anything: the row now carries the full token on its `title`, and the panel header shows it in full when the row is selected.

## Test plan

`tests/behaviors/behaviors-browse-navigation.spec.ts` — **9/9** (7 existing + 2 new). Measured, not eyeballed:

- [x] `whiteSpace === 'nowrap'`, token renders on exactly **1** line, gap to the variant column `>= 0`
- [x] Forced to **2.4rem** — the zoomed-in condition that produced the screenshot — still 1 line, still no overlap, and `scrollWidth > clientWidth` proves the ellipsis is absorbing the overflow rather than the text spilling
- [x] Manually checked at 400px, 760px and 1280px viewports

Closes #699