### PR TITLE
fix(#701,#703,#704,#705): x-dropdown examples are real dropdowns that stay put

### DIFF
--- a/data/behavior-examples.json
+++ b/data/behavior-examples.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/build-behavior-examples.mjs",
   "source": "pages/behaviors.html",
-  "count": 51,
+  "count": 52,
   "demoBlocks": 88,
   "examples": {
     "x-ripple": {
@@ -58,7 +58,7 @@
         "<div x-alert type=\"success\" message=\"Success alert message\"></div>",
         "<div x-alert type=\"warning\" message=\"Warning alert message\"></div>",
         "<div x-alert type=\"error\" message=\"Error alert message\"></div>",
-        "<div x-alert type=\"info\" title=\"Dismissible\" message=\"Click the \u00d7 to dismiss this alert\" dismissible></div>"
+        "<div x-alert type=\"info\" title=\"Dismissible\" message=\"Click the × to dismiss this alert\" dismissible></div>"
       ]
     },
     "x-popover": {
@@ -96,7 +96,7 @@
       "alternates": []
     },
     "x-kbd": {
-      "source": "<p>Press <span x-kbd>Ctrl</span> + <span x-kbd>S</span> to save, or <span x-kbd>\u2318</span> + <span x-kbd>K</span> on Mac.</p>",
+      "source": "<p>Press <span x-kbd>Ctrl</span> + <span x-kbd>S</span> to save, or <span x-kbd>⌘</span> + <span x-kbd>K</span> on Mac.</p>",
       "alternates": []
     },
     "x-image": {
@@ -142,7 +142,7 @@
       "alternates": []
     },
     "x-heartbeat": {
-      "source": "<button class=\"effect-demo\" x-heartbeat>\ud83d\udc93 Heartbeat</button>",
+      "source": "<button class=\"effect-demo\" x-heartbeat>💓 Heartbeat</button>",
       "alternates": []
     },
     "x-fadein": {
@@ -165,45 +165,45 @@
       "alternates": []
     },
     "x-confetti": {
-      "source": "<button variant=\"primary\" x-confetti>\ud83c\udf8a Confetti</button>",
+      "source": "<button variant=\"primary\" x-confetti>🎊 Confetti</button>",
       "alternates": []
     },
     "x-fireworks": {
-      "source": "<button variant=\"primary\" x-fireworks>\ud83c\udf86 Fireworks</button>",
+      "source": "<button variant=\"primary\" x-fireworks>🎆 Fireworks</button>",
       "alternates": []
     },
     "x-snow": {
-      "source": "<button variant=\"primary\" x-snow>\u2744\ufe0f Snow</button>",
+      "source": "<button variant=\"primary\" x-snow>❄️ Snow</button>",
       "alternates": []
     },
     "x-sparkle": {
-      "source": "<button variant=\"primary\" x-sparkle>\u2728 Sparkle</button>",
+      "source": "<button variant=\"primary\" x-sparkle>✨ Sparkle</button>",
       "alternates": []
     },
     "x-glow": {
-      "source": "<button variant=\"primary\" x-glow>\ud83d\udca1 Glow</button>",
+      "source": "<button variant=\"primary\" x-glow>💡 Glow</button>",
       "alternates": []
     },
     "x-rainbow": {
-      "source": "<button variant=\"primary\" x-rainbow>\ud83c\udf08 Rainbow</button>",
+      "source": "<button variant=\"primary\" x-rainbow>🌈 Rainbow</button>",
       "alternates": []
     },
     "x-copy": {
-      "source": "<button variant=\"primary\" x-copy copy-text=\"Text copied to clipboard!\">\ud83d\udccb Copy Text</button>",
+      "source": "<button variant=\"primary\" x-copy copy-text=\"Text copied to clipboard!\">📋 Copy Text</button>",
       "alternates": [
-        "<button variant=\"primary\" x-copy copy-text=\"npm install wb-framework\">\ud83d\udccb Copy Command</button>"
+        "<button variant=\"primary\" x-copy copy-text=\"npm install wb-framework\">📋 Copy Command</button>"
       ]
     },
     "x-share": {
-      "source": "<button variant=\"secondary\" x-share share-title=\"wb-starter\" share-url=\"https://example.com\">\ud83d\udce4 Share</button>",
+      "source": "<button variant=\"secondary\" x-share share-title=\"wb-starter\" share-url=\"https://example.com\">📤 Share</button>",
       "alternates": []
     },
     "x-print": {
-      "source": "<button variant=\"secondary\" x-print>\ud83d\udda8\ufe0f Print</button>",
+      "source": "<button variant=\"secondary\" x-print>🖨️ Print</button>",
       "alternates": []
     },
     "x-fullscreen": {
-      "source": "<button variant=\"secondary\" x-fullscreen>\u26f6 Fullscreen</button>",
+      "source": "<button variant=\"secondary\" x-fullscreen>⛶ Fullscreen</button>",
       "alternates": []
     },
     "x-clock": {
@@ -219,7 +219,7 @@
       "alternates": []
     },
     "x-darkmode": {
-      "source": "<button variant=\"primary\" x-darkmode>\ud83c\udf19 Toggle Dark Mode</button>",
+      "source": "<button variant=\"primary\" x-darkmode>🌙 Toggle Dark Mode</button>",
       "alternates": []
     },
     "x-truncate": {
@@ -231,12 +231,19 @@
       "alternates": []
     },
     "x-details": {
-      "source": "<details summary=\"Trail conditions\" animated>\n  <img src=\"https://picsum.photos/seed/details/480/200\" alt=\"Trail through autumn woodland\" width=\"480\" height=\"200\">\n  <p>Open to show the summary text is authored via the <code>summary</code>\n     attribute \u2014 it reads \"Details\" only when none is set.</p>\n</details>",
+      "source": "<details summary=\"Trail conditions\" animated>\n  <img src=\"https://picsum.photos/seed/details/480/200\" alt=\"Trail through autumn woodland\" width=\"480\" height=\"200\">\n  <p>Open to show the summary text is authored via the <code>summary</code>\n     attribute — it reads \"Details\" only when none is set.</p>\n</details>",
       "alternates": []
     },
     "x-code": {
-      "source": "<code language=\"javascript\">\n// Debounce \u2014 delay a call until the caller stops firing.\nexport function debounce(fn, wait = 200) {\n  let timer = null;\n  return function debounced(...args) {\n    clearTimeout(timer);\n    timer = setTimeout(() =&gt; fn.apply(this, args), wait);\n  };\n}\n\n// Throttle \u2014 run at most once per interval.\nexport function throttle(fn, interval = 100) {\n  let last = 0;\n  return function throttled(...args) {\n    const now = Date.now();\n    if (now - last &lt; interval) return;\n    last = now;\n    return fn.apply(this, args);\n  };\n}\n\nconst onResize = debounce(() =&gt; {\n  const { innerWidth: w, innerHeight: h } = window;\n  console.log(`viewport ${w}x${h}`);\n}, 250);\n\nwindow.addEventListener('resize', onResize);\n</code>",
+      "source": "<code language=\"javascript\">\n// Debounce — delay a call until the caller stops firing.\nexport function debounce(fn, wait = 200) {\n  let timer = null;\n  return function debounced(...args) {\n    clearTimeout(timer);\n    timer = setTimeout(() =&gt; fn.apply(this, args), wait);\n  };\n}\n\n// Throttle — run at most once per interval.\nexport function throttle(fn, interval = 100) {\n  let last = 0;\n  return function throttled(...args) {\n    const now = Date.now();\n    if (now - last &lt; interval) return;\n    last = now;\n    return fn.apply(this, args);\n  };\n}\n\nconst onResize = debounce(() =&gt; {\n  const { innerWidth: w, innerHeight: h } = window;\n  console.log(`viewport ${w}x${h}`);\n}, 250);\n\nwindow.addEventListener('resize', onResize);\n</code>",
       "alternates": []
+    },
+    "x-dropdown": {
+      "source": "<div x-dropdown label=\"Assign to\">\n  <button type=\"button\"><img src=\"https://picsum.photos/seed/ada/28/28\" alt=\"\" width=\"28\" height=\"28\"> Ada Lovelace</button>\n  <button type=\"button\"><img src=\"https://picsum.photos/seed/grace/28/28\" alt=\"\" width=\"28\" height=\"28\"> Grace Hopper</button>\n  <button type=\"button\"><img src=\"https://picsum.photos/seed/alan/28/28\" alt=\"\" width=\"28\" height=\"28\"> Alan Turing</button>\n  <button type=\"button\"><img src=\"https://picsum.photos/seed/katherine/28/28\" alt=\"\" width=\"28\" height=\"28\"> Katherine Johnson</button>\n  <button type=\"button\">Invite someone…</button>\n</div>",
+      "alternates": [
+        "<div x-dropdown items=\"Profile,Settings,Billing,Team,Sign out\" label=\"Account\"></div>",
+        "<div x-dropdown label=\"Opens upward\" position=\"top-start\">\n  <button type=\"button\"><img src=\"https://picsum.photos/seed/ada/28/28\" alt=\"\" width=\"28\" height=\"28\"> Ada Lovelace</button>\n  <button type=\"button\"><img src=\"https://picsum.photos/seed/grace/28/28\" alt=\"\" width=\"28\" height=\"28\"> Grace Hopper</button>\n  <button type=\"button\"><img src=\"https://picsum.photos/seed/alan/28/28\" alt=\"\" width=\"28\" height=\"28\"> Alan Turing</button>\n  <button type=\"button\">Invite someone…</button>\n</div>"
+      ]
     }
   }
 }

--- a/index.html
+++ b/index.html
@@ -27,15 +27,15 @@
   <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
 
   <!-- Layer 1: Foundation (render-blocking, already highest priority — no preload needed) -->
-  <link rel="stylesheet" href="src/styles/normalize.css?v=ff8af6e">
-  <link rel="stylesheet" href="src/styles/themes.css?v=ff8af6e">
-  <link rel="stylesheet" href="src/styles/site.css?v=ff8af6e">
-  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=ff8af6e">
-  <link rel="modulepreload" href="src/core/wb.js?v=ff8af6e">
-  <link rel="modulepreload" href="src/core/site-engine.js?v=ff8af6e">
+  <link rel="stylesheet" href="src/styles/normalize.css?v=3a7eff8">
+  <link rel="stylesheet" href="src/styles/themes.css?v=3a7eff8">
+  <link rel="stylesheet" href="src/styles/site.css?v=3a7eff8">
+  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=3a7eff8">
+  <link rel="modulepreload" href="src/core/wb.js?v=3a7eff8">
+  <link rel="modulepreload" href="src/core/site-engine.js?v=3a7eff8">
 
   <!-- Page Transitions CSS -->
-  <link rel="stylesheet" href="src/styles/transitions.css?v=ff8af6e">
+  <link rel="stylesheet" href="src/styles/transitions.css?v=3a7eff8">
   <!-- Navbar CSS already loads via site.css's own @import — no separate link needed. -->
 
   <!-- Fonts -->
@@ -92,9 +92,9 @@
   </template>
 
   <!-- Premium Navbar Scroll Effect -->
-  <script src="src/lib/premium-navbar.js?v=ff8af6e"></script>
+  <script src="src/lib/premium-navbar.js?v=3a7eff8"></script>
 
   <!-- Main Application Bootstrap -->
-  <script type="module" src="./src/main.js?v=ff8af6e"></script>
+  <script type="module" src="./src/main.js?v=3a7eff8"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wb-starter",
-  "version": "3.0.44",
+  "version": "3.0.45",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wb-starter",
-      "version": "3.0.44",
+      "version": "3.0.45",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wb-starter",
-  "version": "3.0.44",
+  "version": "3.0.45",
   "type": "module",
   "description": "Modern website starter kit powered by WB Behaviors",
   "main": "index.html",

--- a/pages/behaviors.html
+++ b/pages/behaviors.html
@@ -435,6 +435,41 @@
     const liveDoc = document.getElementById('behaviors-live-doc');
     let liveDocBody = document.getElementById('behaviors-live-doc-body');
 
+    // #703 -- John: "Make sure when dropped down the height is right." An
+    // example that opens a floating layer (dropdown menu, tooltip, popover)
+    // positions it ABSOLUTELY, so it adds nothing to the stage's layout height:
+    // measured at 375x812 the open x-dropdown menu ran to 549px while the stage
+    // ended at 321px and the code panel started there, so the menu rendered
+    // straight over the code. Standard 15: an overlay must not overflow its
+    // parent. Grow the stage to whatever the example actually put on screen.
+    const STAGE_MIN_PX = 96;   // 6rem, matching .behaviors-live__stage in behaviors.css
+    let fitQueued = false;
+    function fitStageToOverlays() {
+      if (fitQueued) return;
+      fitQueued = true;
+      requestAnimationFrame(() => {
+        fitQueued = false;
+        const stageTop = liveStage.getBoundingClientRect().top;
+        let deepest = 0;
+        for (const el of liveStage.querySelectorAll('*')) {
+          const r = el.getBoundingClientRect();
+          if (r.width === 0 && r.height === 0) continue;   // display:none, not open
+          deepest = Math.max(deepest, r.bottom - stageTop);
+        }
+        const padding = parseFloat(getComputedStyle(liveStage).paddingBottom) || 0;
+        const wanted = Math.max(STAGE_MIN_PX, Math.ceil(deepest + padding));
+        // Only ever grow while one example is shown -- shrinking mid-interaction
+        // makes the panel jump under the reader's cursor. showLive() resets it.
+        const current = parseFloat(liveStage.style.minHeight) || 0;
+        if (wanted > current) liveStage.style.minHeight = wanted + 'px';
+      });
+    }
+
+    // A menu opens on click and, for trigger="hover", on pointer entry.
+    liveStage.addEventListener('click', fitStageToOverlays);
+    liveStage.addEventListener('mouseover', fitStageToOverlays);
+    liveStage.addEventListener('focusin', fitStageToOverlays);
+
     // Cache: the same doc is re-requested every time a reader arrows back over
     // a behavior, and a 404 is worth remembering too (49 docs, 143 entries --
     // most misses are permanent).
@@ -1142,6 +1177,30 @@
     // a behavior stops from bubbling.
     WATCHED.forEach((type) => liveStage.addEventListener(type, logEvent, true));
 
+    // #705 -- John: "leave it there but log the event via handler". WATCHED only
+    // covers native types, so a behavior's OWN event -- wb:dropdown:select,
+    // wb:autocomplete:select, wb:cardexpandable:toggle, dozens more -- bubbled
+    // out unlogged, and the panel showed nothing for the one interaction the
+    // example exists to demonstrate (while the handler snippet below it told the
+    // reader to listen for exactly that event).
+    //
+    // There is no registry of behavior event names to subscribe to, and
+    // addEventListener has no wildcard. Wrapping dispatchEvent is the one place
+    // every custom event must pass through. The wrapper only OBSERVES: it always
+    // calls through, never swallows, and it ignores anything dispatched outside
+    // the stage, so nothing about how the page or the behaviors run changes.
+    const CUSTOM_EVENT_RE = /^(wb|x):/;
+    const nativeDispatch = EventTarget.prototype.dispatchEvent;
+    EventTarget.prototype.dispatchEvent = function (event) {
+      const result = nativeDispatch.call(this, event);
+      try {
+        if (event && CUSTOM_EVENT_RE.test(event.type) && this instanceof Node && liveStage.contains(this)) {
+          logEvent({ type: event.type, target: this });
+        }
+      } catch { /* logging must never break the event it is watching */ }
+      return result;
+    };
+
     let eventsSnippet = document.getElementById('behaviors-live-events-snippet');
 
     /** The wiring a reader would copy to handle this example's events. */
@@ -1257,6 +1316,8 @@
       }
 
       liveNote.textContent = optionDescription(token, prop) || 'running live';
+      // #703: drop the previous example's grown height before measuring this one.
+      liveStage.style.minHeight = '';
       liveStage.innerHTML = src;
       const rootId = assignExampleIds(token, optionText);
       resetEvents(liveStage.firstElementChild && liveStage.firstElementChild.tagName.toLowerCase(), token, rootId);
@@ -1272,6 +1333,9 @@
       const described = optionDescription(token, prop);
       const summary = described || summarise(liveStage.firstElementChild);
       if (summary) liveNote.textContent = summary;
+      // #703: an example can render something taller than the stage's 6rem
+      // floor even before anything is opened.
+      fitStageToOverlays();
     }
 
     // #666 — John: "allow the user to use the down arrow for each item shown in

--- a/project-index.html
+++ b/project-index.html
@@ -7,8 +7,8 @@
     <title>Project Index</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
-    <link rel="stylesheet" href="src/styles/themes.css?v=ff8af6e">
-    <link rel="stylesheet" href="src/styles/site.css?v=ff8af6e">
+    <link rel="stylesheet" href="src/styles/themes.css?v=3a7eff8">
+    <link rel="stylesheet" href="src/styles/site.css?v=3a7eff8">
     <script type="module">
       import WB from './src/core/wb.js';
       WB.init({ autoInject: true });

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -3,7 +3,7 @@
  * Regenerated on every commit via .husky/pre-commit.
  */
 export const VERSION = {
-  "version": "3.0.44",
-  "commit": "ff8af6e",
-  "builtAt": "2026-08-20T20:59:41.190Z"
+  "version": "3.0.45",
+  "commit": "3a7eff8",
+  "builtAt": "2026-08-20T21:33:02.553Z"
 };

--- a/src/wb-viewmodels/dropdown.js
+++ b/src/wb-viewmodels/dropdown.js
@@ -104,7 +104,12 @@ export function dropdown(element, options = {}) {
     childElements.forEach(child => {
       child.classList.add('wb-dropdown__item');
       Object.assign(child.style, {
-        display: 'block',
+        // #701: flex, not block -- an item can carry an avatar or icon next to
+        // its label (the showcase example does), and block left the image and
+        // the text sitting on different baselines.
+        display: 'flex',
+        alignItems: 'center',
+        gap: '0.5rem',
         padding: '0.5rem 0.75rem',
         cursor: 'pointer',
         transition: 'background 0.15s',
@@ -216,7 +221,10 @@ export function dropdown(element, options = {}) {
     });
     element.addEventListener('mouseleave', () => {
       hoverCloseTimer = setTimeout(() => {
-        if (isOpen) toggle();
+        // #704: close(), NOT toggle(). toggle() early-returns while a hover menu
+        // is open -- that guard exists to stop a CLICK closing it -- so routing
+        // the leave through toggle() meant a hover dropdown never closed at all.
+        close();
         hoverCloseTimer = null;
       }, 150);
     });

--- a/tests/behaviors/dropdown-examples.spec.ts
+++ b/tests/behaviors/dropdown-examples.spec.ts
@@ -1,0 +1,292 @@
+/**
+ * #701 — every x-dropdown example on the behaviors showcase must be a real
+ * dropdown: 4–5 options, at least one carrying an image that actually loads,
+ * a trigger that opens the menu and closes it again.
+ *
+ * Before this, all 8 rows rendered `<div x-dropdown>Example x-dropdown
+ * content</div>` — a trigger with an EMPTY menu. Nothing opened, and every
+ * variant (position, trigger, closeOnSelect, closeOnOutside) described the
+ * behaviour of a menu that had no items.
+ *
+ * John: "shouldn't x-dropdown all have 4 or 5 options, including images" /
+ * "create unit test for all x-dropdown examples". So this walks EVERY
+ * x-dropdown row in the browse list, not just the first.
+ */
+import { test, expect, Page } from '@playwright/test';
+
+const MIN_OPTIONS = 4;
+const MAX_OPTIONS = 5;
+
+async function openShowcase(page: Page) {
+  await page.goto('/?page=behaviors');
+  await page.waitForSelector('#behaviors-search', { timeout: 30000 });
+  await page.fill('#behaviors-search', 'dropdown');
+  await page.waitForFunction(
+    () => document.querySelectorAll('.behaviors-search-results__row').length > 0,
+    { timeout: 30000 },
+  );
+}
+
+/** Every x-dropdown row's variant label, in list order. */
+async function dropdownVariants(page: Page): Promise<string[]> {
+  return page.evaluate(() =>
+    [...document.querySelectorAll('.behaviors-search-results__row')]
+      .filter((r) => r.getAttribute('data-browse-token') === 'x-dropdown')
+      .map((r) => r.getAttribute('data-variant') || ''),
+  );
+}
+
+/** Render the nth x-dropdown row and report what its example actually built. */
+async function renderNth(page: Page, index: number) {
+  return page.evaluate(async (i: number) => {
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+    const rows = [...document.querySelectorAll('.behaviors-search-results__row')]
+      .filter((r) => r.getAttribute('data-browse-token') === 'x-dropdown') as HTMLElement[];
+    rows[i].click();
+    await sleep(350);
+
+    const root = document.querySelector('#behaviors-live-stage .wb-dropdown') as HTMLElement | null;
+    if (!root) return null;
+    const menu = root.querySelector('.wb-dropdown__menu') as HTMLElement;
+    const items = [...menu.querySelectorAll('.wb-dropdown__item')] as HTMLElement[];
+    const imgs = [...menu.querySelectorAll('img')] as HTMLImageElement[];
+
+    // Wait for the avatars rather than racing them.
+    for (let attempt = 0; attempt < 20 && imgs.some((im) => !im.complete); attempt++) await sleep(100);
+
+    const trigger = (root.querySelector('.wb-dropdown__trigger') || root) as HTMLElement;
+    const variant = rows[i].getAttribute('data-variant') || '';
+
+    // trigger="hover" is pointer-driven ON PURPOSE: dropdown()'s toggle() has
+    // `if (config.trigger === 'hover' && isOpen) return`, so a click cannot
+    // close a hover menu -- mouseleave does, after a 150ms grace period that
+    // lets the pointer travel from the trigger into the menu. Drive each
+    // variant the way it is meant to be driven.
+    let openedDisplay: string;
+    let closedDisplay: string;
+    if (variant === 'hover') {
+      root.dispatchEvent(new MouseEvent('mouseenter', { bubbles: false }));
+      await sleep(200);
+      openedDisplay = getComputedStyle(menu).display;
+      root.dispatchEvent(new MouseEvent('mouseleave', { bubbles: false }));
+      await sleep(400);
+      closedDisplay = getComputedStyle(menu).display;
+    } else {
+      trigger.click();
+      await sleep(200);
+      openedDisplay = getComputedStyle(menu).display;
+      trigger.click();
+      await sleep(200);
+      closedDisplay = getComputedStyle(menu).display;
+    }
+
+    return {
+      variant,
+      itemCount: items.length,
+      imgCount: imgs.length,
+      imgsLoaded: imgs.filter((im) => im.complete && im.naturalWidth > 0).length,
+      itemsWithText: items.filter((el) => (el.textContent || '').trim().length > 0).length,
+      alignedRows: items.filter((el) => getComputedStyle(el).display === 'flex').length,
+      openedDisplay,
+      closedDisplay,
+    };
+  }, index);
+}
+
+test.describe('#701 — every x-dropdown example is a real dropdown', () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test('the showcase actually lists x-dropdown rows to check', async ({ page }) => {
+    await openShowcase(page);
+    const variants = await dropdownVariants(page);
+    expect(variants.length, 'expected the x-dropdown variants to be listed').toBeGreaterThan(0);
+  });
+
+  test('every x-dropdown row renders 4-5 options, with images that load', async ({ page }) => {
+    test.setTimeout(120_000);
+    await openShowcase(page);
+    const variants = await dropdownVariants(page);
+
+    const failures: string[] = [];
+    for (let i = 0; i < variants.length; i++) {
+      const r = await renderNth(page, i);
+      const label = `x-dropdown/${variants[i] || '(none)'}`;
+
+      if (!r) { failures.push(`${label}: rendered no .wb-dropdown at all`); continue; }
+      if (r.itemCount < MIN_OPTIONS || r.itemCount > MAX_OPTIONS) {
+        failures.push(`${label}: ${r.itemCount} options (want ${MIN_OPTIONS}-${MAX_OPTIONS})`);
+      }
+      if (r.itemsWithText !== r.itemCount) {
+        failures.push(`${label}: ${r.itemCount - r.itemsWithText} option(s) render no text`);
+      }
+      if (r.imgsLoaded < 1) {
+        failures.push(`${label}: ${r.imgCount} image(s) in the menu, ${r.imgsLoaded} actually loaded`);
+      }
+      if (r.alignedRows !== r.itemCount) {
+        failures.push(`${label}: ${r.itemCount - r.alignedRows} option(s) not laid out as a flex row — an avatar and its label would not align`);
+      }
+      if (r.openedDisplay === 'none') failures.push(`${label}: the trigger did not open the menu`);
+      if (r.closedDisplay !== 'none') failures.push(`${label}: the menu did not close again`);
+    }
+
+    expect(failures, failures.join('\n')).toEqual([]);
+  });
+
+  test('the code sample shown alongside is the example that ran', async ({ page }) => {
+    await openShowcase(page);
+    await renderNth(page, 0);
+    const code = await page.evaluate(
+      () => document.getElementById('behaviors-live-code')?.textContent || '',
+    );
+    expect(code, 'the sample must show the x-dropdown markup').toContain('x-dropdown');
+    expect(code, 'the sample must show the options, not an empty host').toContain('<button');
+    expect(code, 'the sample must show the images').toContain('<img');
+  });
+});
+
+test.describe('#703 — an opened menu stays inside the stage', () => {
+  for (const [name, viewport] of [
+    ['phone', { width: 375, height: 812 }],
+    ['desktop', { width: 1280, height: 900 }],
+  ] as const) {
+    test(`${name}: the open menu never reaches the code panel`, async ({ page }) => {
+      await page.setViewportSize(viewport);
+      await openShowcase(page);
+
+      const geo = await page.evaluate(async () => {
+        const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+        const rows = [...document.querySelectorAll('.behaviors-search-results__row')]
+          .filter((r) => r.getAttribute('data-browse-token') === 'x-dropdown') as HTMLElement[];
+        // bottom-* opens downward, toward the code panel — the failing direction.
+        const row = rows.find((r) => (r.getAttribute('data-variant') || '').startsWith('bottom')) || rows[0];
+        row.click();
+        await sleep(400);
+
+        const stage = document.getElementById('behaviors-live-stage')!;
+        const code = document.getElementById('behaviors-live-code')!;
+        const root = stage.querySelector('.wb-dropdown') as HTMLElement;
+        const menu = root.querySelector('.wb-dropdown__menu') as HTMLElement;
+        const trigger = (root.querySelector('.wb-dropdown__trigger') || root) as HTMLElement;
+
+        const closedHeight = Math.round(stage.getBoundingClientRect().height);
+        trigger.click();
+        await sleep(400);
+
+        const sb = stage.getBoundingClientRect();
+        const mb = menu.getBoundingClientRect();
+        const cb = code.getBoundingClientRect();
+        return {
+          closedHeight,
+          openHeight: Math.round(sb.height),
+          menuBottom: Math.round(mb.bottom),
+          stageBottom: Math.round(sb.bottom),
+          codeTop: Math.round(cb.top),
+        };
+      });
+
+      expect(geo.openHeight, 'the stage must grow to hold the open menu').toBeGreaterThan(geo.closedHeight);
+      expect(geo.menuBottom, 'the menu must end inside the stage (Standard §15)')
+        .toBeLessThanOrEqual(geo.stageBottom + 1);
+      expect(geo.menuBottom, 'the menu must not reach the code panel')
+        .toBeLessThanOrEqual(geo.codeTop);
+    });
+  }
+
+  test('the stage returns to its normal height for the next example', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await openShowcase(page);
+
+    const heights = await page.evaluate(async () => {
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      const stage = document.getElementById('behaviors-live-stage')!;
+      const rows = [...document.querySelectorAll('.behaviors-search-results__row')]
+        .filter((r) => r.getAttribute('data-browse-token') === 'x-dropdown') as HTMLElement[];
+
+      rows[0].click();
+      await sleep(400);
+      const root = stage.querySelector('.wb-dropdown') as HTMLElement;
+      (root.querySelector('.wb-dropdown__trigger') as HTMLElement).click();
+      await sleep(400);
+      const opened = Math.round(stage.getBoundingClientRect().height);
+
+      rows[1].click();          // a different example
+      await sleep(500);
+      const afterSwitch = Math.round(stage.getBoundingClientRect().height);
+      return { opened, afterSwitch };
+    });
+
+    expect(heights.afterSwitch, 'the panel must not stay stretched after switching examples')
+      .toBeLessThan(heights.opened);
+  });
+});
+
+test.describe('#704 — a hover dropdown closes again', () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test('trigger="hover" opens on pointer entry and closes on leave', async ({ page }) => {
+    await openShowcase(page);
+    const state = await page.evaluate(async () => {
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      const row = [...document.querySelectorAll('.behaviors-search-results__row')]
+        .find((r) => r.getAttribute('data-browse-token') === 'x-dropdown'
+                  && r.getAttribute('data-variant') === 'hover') as HTMLElement;
+      row.click();
+      await sleep(400);
+      const root = document.querySelector('#behaviors-live-stage .wb-dropdown') as HTMLElement;
+      const menu = root.querySelector('.wb-dropdown__menu') as HTMLElement;
+
+      root.dispatchEvent(new MouseEvent('mouseenter'));
+      await sleep(250);
+      const opened = getComputedStyle(menu).display;
+
+      root.dispatchEvent(new MouseEvent('mouseleave'));
+      await sleep(600);   // 150ms grace + slack
+      const closed = getComputedStyle(menu).display;
+      return { opened, closed };
+    });
+
+    expect(state.opened, 'hovering must open it').not.toBe('none');
+    expect(state.closed, 'leaving must close it — toggle() swallowed this before #704').toBe('none');
+  });
+});
+
+test.describe('#705 — selecting leaves the example alone and gets logged', () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test('picking an option does not navigate or re-render, and appears in the event log', async ({ page }) => {
+    await openShowcase(page);
+
+    const result = await page.evaluate(async () => {
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      const row = [...document.querySelectorAll('.behaviors-search-results__row')]
+        .find((r) => r.getAttribute('data-browse-token') === 'x-dropdown'
+                  && r.getAttribute('data-variant') === 'click') as HTMLElement;
+      row.click();
+      await sleep(400);
+
+      const urlBefore = location.href;
+      const root = document.querySelector('#behaviors-live-stage .wb-dropdown') as HTMLElement;
+      const menu = root.querySelector('.wb-dropdown__menu') as HTMLElement;
+      (root.querySelector('.wb-dropdown__trigger') as HTMLElement).click();
+      await sleep(300);
+
+      const item = menu.querySelector('.wb-dropdown__item') as HTMLElement;
+      const itemTag = item.tagName;
+      item.click();
+      await sleep(400);
+
+      return {
+        itemTag,
+        urlUnchanged: location.href === urlBefore,
+        stillRendered: !!document.querySelector('#behaviors-live-stage .wb-dropdown'),
+        logged: [...document.querySelectorAll('.behaviors-live__events-type')].map((e) => e.textContent || ''),
+      };
+    });
+
+    expect(result.itemTag, 'a pickable option is a button — an <a href="#"> navigates').toBe('BUTTON');
+    expect(result.urlUnchanged, 'selecting must not change the route').toBe(true);
+    expect(result.stillRendered, 'the example must still be there after a selection').toBe(true);
+    expect(result.logged, "the behavior's own event must reach the panel")
+      .toContain('wb:dropdown:select');
+  });
+});


### PR DESCRIPTION
Four defects, all found from John's one question about the dropdown examples.

## #701 — every x-dropdown example had an EMPTY menu

> "shouldn't x-dropdown all have 4 or 5 options, including images"

All 8 rows rendered `<div x-dropdown>Example x-dropdown content</div>` — a trigger with a menu containing **zero items**. Nothing opened, so `position`, `trigger`, `closeOnSelect` and `closeOnOutside` were all unobservable: each describes the behaviour of a menu that had no items.

`x-dropdown` had no entry in `data/behavior-examples.json`, so `sourceFor()` fell through to the generated stub. Added a real example — **5 options, 4 with avatars** — using the child-element form `dropdown()` supports, which moves children into the menu with their markup intact (that is the form that can carry an `<img>`). Items are flex rows now instead of `display: block`, so an avatar and its label line up.

## #703 — the stage did not grow for the open menu

> "Make sure when dropped down the height is right."

| at 375x812 | top | bottom |
|---|---|---|
| stage | 213 | **321** |
| open menu | 298 | **549** |
| code panel | **321** | 717 |

The menu is absolutely positioned, so it contributed nothing to the stage's height and rendered straight over the code panel. `DEMOS-AND-DOCS-STANDARDS.md` **§15**: an overlay must not overflow its parent.

The stage now grows to contain whatever the example opened, and resets on the next render. Not dropdown-specific — any tooltip, popover or menu in the stage gets the same.

## #704 — `trigger="hover"` could never close

Found by the new test walking *every* variant, not just the first. Hovering opened the menu; leaving never closed it. Measured: `display: block` still, 600ms after `mouseleave`.

```js
const toggle = () => { if (config.trigger === 'hover' && isOpen) return; … };   // stops a CLICK closing it
element.addEventListener('mouseleave', () => setTimeout(() => { if (isOpen) toggle(); }, 150));  // …and the close
```

The guard exists to stop a click closing a hover menu — it also swallowed the only thing that closes it. `mouseleave` calls `close()` directly now.

## #705 — selecting reset the page, and the event was never logged

> "do not reset the behaviors page on any select etc. leave it there but log the event via handler"

Options were `<a href="#">`, and `dropdown()` deliberately does not `preventDefault()` on a link, so picking one navigated and the reader lost the example. Pickable options are `<button type="button">` now.

And `WATCHED = ['click','change','input','submit','toggle']` — native types only — so the behavior's **own** event never reached the panel. The panel said *"interact with the example above"* while the handler snippet right below told the reader to listen for `wb:dropdown:select`, which was never shown.

`dispatchEvent` is now wrapped: observe-only, always calls through, ignores anything dispatched outside the stage. Any `wb:` / `x:` event an example fires is logged, generically — no hardcoded dropdown list, so `wb:autocomplete:select`, `wb:cardexpandable:toggle` and the rest work too.

## Test plan

`tests/behaviors/dropdown-examples.spec.ts` — **8/8**, walking every x-dropdown row:

- [x] every row: 4–5 options, all with text, ≥1 image with `naturalWidth > 0`, items laid out as flex rows, trigger opens and closes
- [x] the code sample shown is the example that ran (contains `x-dropdown`, `<button`, `<img`)
- [x] #703 at 375x812 **and** 1280x900: the stage grows, the menu ends inside it, and never reaches the code panel
- [x] #703: the stage returns to normal height when a different example is selected
- [x] #704: hover opens on entry, closes after leave
- [x] #705: selecting keeps the URL, keeps the example rendered, and logs `wb:dropdown:select`

`behaviors-browse-navigation.spec.ts` — 9/9, unaffected.

Closes #701
Closes #703
Closes #704
Closes #705