### PR TITLE
fix(#707,#708): the menu sizes to its content; select says WHICH option

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,15 +27,15 @@
   <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
 
   <!-- Layer 1: Foundation (render-blocking, already highest priority — no preload needed) -->
-  <link rel="stylesheet" href="src/styles/normalize.css?v=3a7eff8">
-  <link rel="stylesheet" href="src/styles/themes.css?v=3a7eff8">
-  <link rel="stylesheet" href="src/styles/site.css?v=3a7eff8">
-  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=3a7eff8">
-  <link rel="modulepreload" href="src/core/wb.js?v=3a7eff8">
-  <link rel="modulepreload" href="src/core/site-engine.js?v=3a7eff8">
+  <link rel="stylesheet" href="src/styles/normalize.css?v=48479aa">
+  <link rel="stylesheet" href="src/styles/themes.css?v=48479aa">
+  <link rel="stylesheet" href="src/styles/site.css?v=48479aa">
+  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=48479aa">
+  <link rel="modulepreload" href="src/core/wb.js?v=48479aa">
+  <link rel="modulepreload" href="src/core/site-engine.js?v=48479aa">
 
   <!-- Page Transitions CSS -->
-  <link rel="stylesheet" href="src/styles/transitions.css?v=3a7eff8">
+  <link rel="stylesheet" href="src/styles/transitions.css?v=48479aa">
   <!-- Navbar CSS already loads via site.css's own @import — no separate link needed. -->
 
   <!-- Fonts -->
@@ -92,9 +92,9 @@
   </template>
 
   <!-- Premium Navbar Scroll Effect -->
-  <script src="src/lib/premium-navbar.js?v=3a7eff8"></script>
+  <script src="src/lib/premium-navbar.js?v=48479aa"></script>
 
   <!-- Main Application Bootstrap -->
-  <script type="module" src="./src/main.js?v=3a7eff8"></script>
+  <script type="module" src="./src/main.js?v=48479aa"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wb-starter",
-  "version": "3.0.45",
+  "version": "3.0.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wb-starter",
-      "version": "3.0.45",
+      "version": "3.0.46",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wb-starter",
-  "version": "3.0.45",
+  "version": "3.0.46",
   "type": "module",
   "description": "Modern website starter kit powered by WB Behaviors",
   "main": "index.html",

--- a/pages/behaviors.html
+++ b/pages/behaviors.html
@@ -1235,6 +1235,24 @@
       // #675: an id beats a tag selector -- `document.querySelector('button')`
       // grabs the first button on the READER's page, not this example.
       const sel = rootId ? '#' + rootId : (hostTag ? hostTag : '[' + token + ']');
+
+      // #708 / Standard 27 -- a control that fires its own event should teach
+      // THAT event and the payload it actually carries, not a generic click.
+      // A generic click handler tells a reader nothing about how to know WHICH
+      // option was picked. Same precedent as the file-upload snippet above.
+      const CUSTOM_EVENT_SNIPPETS = {
+        'x-dropdown': [
+          `el.addEventListener('wb:dropdown:select', (e) => {`,
+          `  const { id, index, value, href } = e.detail;`,
+          `  console.log('picked', { id, index, value, href });`,
+          `});`,
+        ],
+      };
+      const custom = CUSTOM_EVENT_SNIPPETS[token];
+      if (custom) {
+        return [`const el = document.querySelector('${sel}');`, ``, ...custom].join('\n');
+      }
+
       return [
         `const el = document.querySelector('${sel}');`,
         ``,

--- a/project-index.html
+++ b/project-index.html
@@ -7,8 +7,8 @@
     <title>Project Index</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
-    <link rel="stylesheet" href="src/styles/themes.css?v=3a7eff8">
-    <link rel="stylesheet" href="src/styles/site.css?v=3a7eff8">
+    <link rel="stylesheet" href="src/styles/themes.css?v=48479aa">
+    <link rel="stylesheet" href="src/styles/site.css?v=48479aa">
     <script type="module">
       import WB from './src/core/wb.js';
       WB.init({ autoInject: true });

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -3,7 +3,7 @@
  * Regenerated on every commit via .husky/pre-commit.
  */
 export const VERSION = {
-  "version": "3.0.45",
-  "commit": "3a7eff8",
-  "builtAt": "2026-08-20T21:33:02.553Z"
+  "version": "3.0.46",
+  "commit": "48479aa",
+  "builtAt": "2026-08-20T21:40:50.082Z"
 };

--- a/src/wb-viewmodels/dropdown.js
+++ b/src/wb-viewmodels/dropdown.js
@@ -93,6 +93,12 @@ export function dropdown(element, options = {}) {
     background:var(--bg-secondary,#1f2937);
     border:1px solid var(--border-color,#374151);
     border-radius:8px;min-width:150px;
+    /* #707 -- John: "the rendered element must be fluid to what it's showing".
+       min-width alone let the menu take its width from the containing block, so
+       a two-word option ("Grace Hopper") wrapped onto two lines with room to
+       spare beside it. max-content sizes it to its widest item; max-width keeps
+       it from ever running past the viewport. */
+    width:max-content;max-width:min(90vw,32rem);
     box-shadow:0 10px 25px rgba(0,0,0,0.2);
     display:none;z-index:1000;overflow:hidden;
     margin-top:4px;
@@ -104,6 +110,9 @@ export function dropdown(element, options = {}) {
     childElements.forEach(child => {
       child.classList.add('wb-dropdown__item');
       Object.assign(child.style, {
+        // #707: the menu is sized to its content, so an option never needs to
+        // wrap -- and a wrapped label misrepresents the component.
+        whiteSpace: 'nowrap',
         // #701: flex, not block -- an item can carry an avatar or icon next to
         // its label (the showcase example does), and block left the image and
         // the text sitting on different baselines.
@@ -125,7 +134,7 @@ export function dropdown(element, options = {}) {
     menu.innerHTML = config.items.map(item => `
       <div class="wb-dropdown__item" style="
         padding:0.5rem 0.75rem;cursor:pointer;
-        transition:background 0.15s;
+        transition:background 0.15s;white-space:nowrap;
       ">${item.trim()}</div>
     `).join('');
     
@@ -181,12 +190,21 @@ export function dropdown(element, options = {}) {
     
     if (item) {
       // Item clicked
-      element.dispatchEvent(new CustomEvent('wb:dropdown:select', { 
-        bubbles: true, 
-        detail: { 
+      // #708 -- John: "when any option is clicked the event must give the option
+      // id or index and the value". Text alone is ambiguous the moment two
+      // options share a label, and it changes whenever the label is reworded, so
+      // a handler had nothing stable to switch on. id when the item has one,
+      // index always; value keeps its old meaning so existing handlers still work.
+      const index = Array.prototype.indexOf.call(
+        menu.querySelectorAll('.wb-dropdown__item'), item);
+      element.dispatchEvent(new CustomEvent('wb:dropdown:select', {
+        bubbles: true,
+        detail: {
+          id: item.id || null,
+          index,
           value: item.textContent.trim(),
-          href: item.href || null 
-        } 
+          href: item.href || null
+        }
       }));
       
       if (config.closeOnSelect) {

--- a/tests/behaviors/dropdown-examples.spec.ts
+++ b/tests/behaviors/dropdown-examples.spec.ts
@@ -21,8 +21,13 @@ async function openShowcase(page: Page) {
   await page.goto('/?page=behaviors');
   await page.waitForSelector('#behaviors-search', { timeout: 30000 });
   await page.fill('#behaviors-search', 'dropdown');
+  // Wait for the x-dropdown rows specifically. The list renders as soon as ANY
+  // match exists, but the browse entries are built after the catalogue fetch
+  // resolves -- waiting on "some row" raced that and left .find() undefined.
   await page.waitForFunction(
-    () => document.querySelectorAll('.behaviors-search-results__row').length > 0,
+    () => [...document.querySelectorAll('.behaviors-search-results__row')]
+      .some((r) => r.getAttribute('data-browse-token') === 'x-dropdown'
+                && r.getAttribute('data-variant') === 'click'),
     { timeout: 30000 },
   );
 }
@@ -170,7 +175,8 @@ test.describe('#703 — an opened menu stays inside the stage', () => {
 
         const closedHeight = Math.round(stage.getBoundingClientRect().height);
         trigger.click();
-        await sleep(400);
+        for (let i = 0; i < 30 && getComputedStyle(menu).display === 'none'; i++) await sleep(50);
+        await sleep(200);   // let the stage's rAF fit run
 
         const sb = stage.getBoundingClientRect();
         const mb = menu.getBoundingClientRect();
@@ -205,8 +211,10 @@ test.describe('#703 — an opened menu stays inside the stage', () => {
       rows[0].click();
       await sleep(400);
       const root = stage.querySelector('.wb-dropdown') as HTMLElement;
+      const menu = root.querySelector('.wb-dropdown__menu') as HTMLElement;
       (root.querySelector('.wb-dropdown__trigger') as HTMLElement).click();
-      await sleep(400);
+      for (let i = 0; i < 30 && getComputedStyle(menu).display === 'none'; i++) await sleep(50);
+      await sleep(200);
       const opened = Math.round(stage.getBoundingClientRect().height);
 
       rows[1].click();          // a different example
@@ -288,5 +296,109 @@ test.describe('#705 — selecting leaves the example alone and gets logged', () 
     expect(result.stillRendered, 'the example must still be there after a selection').toBe(true);
     expect(result.logged, "the behavior's own event must reach the panel")
       .toContain('wb:dropdown:select');
+  });
+});
+
+test.describe('#707 — the menu is sized to what it shows', () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test('no option label wraps, and the menu stays inside the stage', async ({ page }) => {
+    await openShowcase(page);
+
+    const geo = await page.evaluate(async () => {
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      const row = [...document.querySelectorAll('.behaviors-search-results__row')]
+        .find((r) => r.getAttribute('data-browse-token') === 'x-dropdown'
+                  && r.getAttribute('data-variant') === 'click') as HTMLElement;
+      row.click();
+      await sleep(400);
+      const stage = document.getElementById('behaviors-live-stage')!;
+      const root = stage.querySelector('.wb-dropdown') as HTMLElement;
+      const menu = root.querySelector('.wb-dropdown__menu') as HTMLElement;
+      (root.querySelector('.wb-dropdown__trigger') as HTMLElement).click();
+      await sleep(350);
+
+      // Count the LINE BOXES the text actually occupies -- an item's height is
+      // no use here, a 28px avatar makes every row look like two lines.
+      const lineCount = (el: Element) => {
+        let n = 0;
+        const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+        let node: Node | null;
+        while ((node = walker.nextNode())) {
+          if (!node.nodeValue || !node.nodeValue.trim()) continue;
+          const range = document.createRange();
+          range.selectNodeContents(node);
+          n = Math.max(n, range.getClientRects().length);
+        }
+        return n;
+      };
+
+      const items = [...menu.querySelectorAll('.wb-dropdown__item')];
+      return {
+        wrapped: items.filter((i) => lineCount(i) > 1).map((i) => (i.textContent || '').trim()),
+        menuWidth: Math.round(menu.getBoundingClientRect().width),
+        stageWidth: Math.round(stage.getBoundingClientRect().width),
+        itemCount: items.length,
+      };
+    });
+
+    expect(geo.itemCount, 'expected the options to be there to measure').toBeGreaterThan(0);
+    expect(geo.wrapped, 'no option label may wrap — the menu sizes to its content').toEqual([]);
+    expect(geo.menuWidth, 'the menu must not overflow the stage').toBeLessThanOrEqual(geo.stageWidth);
+  });
+});
+
+test.describe('#708 — the select event says WHICH option', () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test('every option reports its own index, id and value', async ({ page }) => {
+    await openShowcase(page);
+
+    const picks = await page.evaluate(async () => {
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      const row = [...document.querySelectorAll('.behaviors-search-results__row')]
+        .find((r) => r.getAttribute('data-browse-token') === 'x-dropdown'
+                  && r.getAttribute('data-variant') === 'click') as HTMLElement;
+
+      const seen: any[] = [];
+      for (const index of [0, 2, 4]) {
+        row.click();                       // re-render, so each pick starts clean
+        await sleep(400);
+        const root = document.querySelector('#behaviors-live-stage .wb-dropdown') as HTMLElement;
+        const menu = root.querySelector('.wb-dropdown__menu') as HTMLElement;
+        (root.querySelector('.wb-dropdown__trigger') as HTMLElement).click();
+        await sleep(250);
+
+        let detail: any = null;
+        root.addEventListener('wb:dropdown:select', (e: any) => { detail = e.detail; }, { once: true });
+        const items = [...menu.querySelectorAll('.wb-dropdown__item')] as HTMLElement[];
+        const expectedText = (items[index].textContent || '').trim();
+        items[index].click();
+        await sleep(250);
+        seen.push({ index, expectedText, detail });
+      }
+      return seen;
+    });
+
+    for (const pick of picks) {
+      expect(pick.detail, `option ${pick.index} fired no wb:dropdown:select`).not.toBeNull();
+      expect(pick.detail.index, `option ${pick.index} reported the wrong index`).toBe(pick.index);
+      expect(pick.detail.value, `option ${pick.index} reported the wrong value`).toBe(pick.expectedText);
+      expect(pick.detail, 'the payload must carry an id field').toHaveProperty('id');
+      expect(pick.detail, 'the payload must keep href').toHaveProperty('href');
+    }
+
+    // The last option is the one an off-by-one would miss.
+    expect(picks[picks.length - 1].detail.index, 'the last option must report its real index').toBe(4);
+  });
+
+  test('the handler snippet teaches that event, not a generic click', async ({ page }) => {
+    await openShowcase(page);
+    await renderNth(page, 0);
+    const snippet = await page.evaluate(
+      () => document.getElementById('behaviors-live-events-snippet')?.textContent || '',
+    );
+    expect(snippet, 'Standard 27 — teach the event the control actually fires').toContain('wb:dropdown:select');
+    expect(snippet, 'and the payload a reader needs').toContain('index');
   });
 });


### PR DESCRIPTION
## #707 — "the rendered element must be fluid to what it's showing"

The menu had `min-width: 150px` and no `width`, so it took its width from the containing block and **wrapped its own labels** — "Grace Hopper" and "Katherine Johnson" each on two lines, with room to spare beside them (your screenshot).

Now `width: max-content`, still floored at `min-width`, capped at `min(90vw, 32rem)` so it can never run past the viewport, and items are `white-space: nowrap`.

Measured after: menu **213px** inside a **347px** stage, every label on one line.

## #708 — "the event must give the option id or index and the value"

`wb:dropdown:select` carried only the item's **text**:

```js
detail: { value: item.textContent.trim(), href: item.href || null }
```

That is ambiguous the moment two options share a label, it changes whenever the label is reworded or translated, and it gives a handler nothing stable to switch on — the showcase made it concrete, where every `value` is a person's name.

```js
detail: { id, index, value, href }
```

`id` when the item has one (every rendered element gets a stable id, #675), `index` always, `value` unchanged so existing handlers keep working. Measured: picking the third option reports `index: 2`, `id: "dropdown-trigger-click-button-3"`, `value: "Alan Turing"`.

The **handler snippet** teaches that event now instead of a generic `click` listener — Standard §27, *"a demo whose control fires a custom event should teach how to listen for it"*. A `console.log('clicked', e.target)` told a reader nothing about how to know which option was picked.

## Test plan

`tests/behaviors/dropdown-examples.spec.ts` — **11/11**

- [x] #707: zero option labels wrap (counted as text **line boxes**, not row height — a 28px avatar makes every row look two lines tall), menu never exceeds the stage
- [x] #708: options 0, 2 and 4 each report their own `index`, matching `value`, and an `id` — including the **last** option, the one an off-by-one would miss
- [x] #708: the snippet contains `wb:dropdown:select` and `index`

Also fixed two races the new tests exposed in the spec itself: it waited for "some row" when the x-dropdown rows only arrive after the catalogue fetch resolves, and it used a fixed sleep where it should poll for the menu to open.

Closes #707
Closes #708