### PR TITLE
fix(#710,#711): columns match height; the example is centred in the stage

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,15 +27,15 @@
   <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
 
   <!-- Layer 1: Foundation (render-blocking, already highest priority — no preload needed) -->
-  <link rel="stylesheet" href="src/styles/normalize.css?v=48479aa">
-  <link rel="stylesheet" href="src/styles/themes.css?v=48479aa">
-  <link rel="stylesheet" href="src/styles/site.css?v=48479aa">
-  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=48479aa">
-  <link rel="modulepreload" href="src/core/wb.js?v=48479aa">
-  <link rel="modulepreload" href="src/core/site-engine.js?v=48479aa">
+  <link rel="stylesheet" href="src/styles/normalize.css?v=0770d53">
+  <link rel="stylesheet" href="src/styles/themes.css?v=0770d53">
+  <link rel="stylesheet" href="src/styles/site.css?v=0770d53">
+  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=0770d53">
+  <link rel="modulepreload" href="src/core/wb.js?v=0770d53">
+  <link rel="modulepreload" href="src/core/site-engine.js?v=0770d53">
 
   <!-- Page Transitions CSS -->
-  <link rel="stylesheet" href="src/styles/transitions.css?v=48479aa">
+  <link rel="stylesheet" href="src/styles/transitions.css?v=0770d53">
   <!-- Navbar CSS already loads via site.css's own @import — no separate link needed. -->
 
   <!-- Fonts -->
@@ -92,9 +92,9 @@
   </template>
 
   <!-- Premium Navbar Scroll Effect -->
-  <script src="src/lib/premium-navbar.js?v=48479aa"></script>
+  <script src="src/lib/premium-navbar.js?v=0770d53"></script>
 
   <!-- Main Application Bootstrap -->
-  <script type="module" src="./src/main.js?v=48479aa"></script>
+  <script type="module" src="./src/main.js?v=0770d53"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wb-starter",
-  "version": "3.0.46",
+  "version": "3.0.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wb-starter",
-      "version": "3.0.46",
+      "version": "3.0.47",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wb-starter",
-  "version": "3.0.46",
+  "version": "3.0.47",
   "type": "module",
   "description": "Modern website starter kit powered by WB Behaviors",
   "main": "index.html",

--- a/pages/behaviors.html
+++ b/pages/behaviors.html
@@ -470,6 +470,40 @@
     liveStage.addEventListener('mouseover', fitStageToOverlays);
     liveStage.addEventListener('focusin', fitStageToOverlays);
 
+    // #710 -- John: "Make the height of the left element same as right element."
+    // CSS alone cannot express it: with align-items:stretch the LIST's own 585
+    // rows also feed the row's intrinsic height, so lifting its max-height grew
+    // both columns to 32,787px (measured) -- the 13,000px page #664 removed.
+    // So the panel is measured and the list is capped to it; the list keeps
+    // scrolling inside itself. Stacked, the cap is dropped and behaviors.css's
+    // fixed max-height applies again -- there is no second column to match.
+    const TWO_COL = matchMedia('(min-width: 60.0625rem)');
+    let syncQueued = false;
+    function syncListHeight() {
+      // Write on the next frame, never inside the observer callback: mutating
+      // layout during delivery is what produces "ResizeObserver loop completed
+      // with undelivered notifications".
+      if (syncQueued) return;
+      syncQueued = true;
+      requestAnimationFrame(() => {
+        syncQueued = false;
+        if (!TWO_COL.matches) {
+          if (resultsEl.style.maxHeight) resultsEl.style.maxHeight = '';
+          return;
+        }
+        const h = liveEl.getBoundingClientRect().height;
+        // Panel hidden (nothing picked yet) -> fall back to the stylesheet.
+        const next = h > 0 ? Math.round(h) + 'px' : '';
+        // Only write on a real change -- an unconditional write re-triggers the
+        // observer every frame for no reason.
+        if (resultsEl.style.maxHeight !== next) resultsEl.style.maxHeight = next;
+      });
+    }
+    // The panel's height drives the list's; the list never drives the panel's,
+    // so this cannot feed back on itself.
+    new ResizeObserver(syncListHeight).observe(liveEl);
+    TWO_COL.addEventListener('change', syncListHeight);
+
     // Cache: the same doc is re-requested every time a reader arrows back over
     // a behavior, and a 404 is worth remembering too (49 docs, 143 entries --
     // most misses are permanent).

--- a/project-index.html
+++ b/project-index.html
@@ -7,8 +7,8 @@
     <title>Project Index</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
-    <link rel="stylesheet" href="src/styles/themes.css?v=48479aa">
-    <link rel="stylesheet" href="src/styles/site.css?v=48479aa">
+    <link rel="stylesheet" href="src/styles/themes.css?v=0770d53">
+    <link rel="stylesheet" href="src/styles/site.css?v=0770d53">
     <script type="module">
       import WB from './src/core/wb.js';
       WB.init({ autoInject: true });

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -3,7 +3,7 @@
  * Regenerated on every commit via .husky/pre-commit.
  */
 export const VERSION = {
-  "version": "3.0.46",
-  "commit": "48479aa",
-  "builtAt": "2026-08-20T21:40:50.082Z"
+  "version": "3.0.47",
+  "commit": "0770d53",
+  "builtAt": "2026-08-20T22:30:44.281Z"
 };

--- a/src/styles/pages/behaviors.css
+++ b/src/styles/pages/behaviors.css
@@ -434,6 +434,31 @@ footer a:hover {
   .behaviors-browse { grid-template-columns: minmax(0, 1fr); }
 }
 
+/* #710 -- John: "Make the height of the left element same as right element."
+   The list was pinned to a fixed max-height (24rem, from #666) while the panel
+   beside it is as tall as its content -- stage + code + events + handler + doc
+   -- so align-items:start left the short column stranded at the top and the two
+   stopped reading as one browse surface. Side by side, the row stretches and the
+   list fills it, still scrolling inside itself. Stacked, there is no second
+   column to match, so the media query above keeps the fixed cap. */
+@media (min-width: 60.0625rem) {
+  /* Deliberately NOT align-items: stretch. Stretching BOTH columns makes the
+     panel's height the row's height, while the row's height depends on the
+     list's cap, which is measured FROM the panel -- a real circle, and the
+     browser said so: "ResizeObserver loop completed with undelivered
+     notifications" x3. With the panel left at `start` its height is its own
+     content, the measurement is stable, and only the list stretches to it. */
+  .behaviors-browse .behaviors-search-results { align-self: stretch; }
+
+  .behaviors-browse .behaviors-search-results {
+    /* The CAP stays -- and is overridden inline with the panel's measured
+       height (see #710 in pages/behaviors.html). max-height:none here made the
+       list's own 585 rows feed the stretched row's intrinsic height, so BOTH
+       columns grew to 32,787px: the 13,000px page #664 removed, back again. */
+    min-height: 0;
+  }
+}
+
 /* The list already sets its own margin-top; inside the grid the grid gap owns
    the spacing, so drop it to keep the two columns top-aligned. */
 .behaviors-browse .behaviors-search-results {
@@ -477,6 +502,14 @@ footer a:hover {
   padding: 1.25rem;
   min-height: 6rem;
   contain: layout;
+  /* #711 -- John: "This element should center vertically. Too much space up
+     here." A block child sits at the top, so every pixel the stage has beyond
+     the example's own height piled up underneath it. align-content centres the
+     content of a BLOCK container without touching horizontal layout, which
+     matters here: switching to flex or grid would stretch a <button> example to
+     full width (align/justify-items: stretch) or shrink an <article> one
+     (start). This changes the one axis that is wrong. */
+  align-content: center;
 }
 
 .behaviors-live__code {

--- a/tests/behaviors/behaviors-browse-navigation.spec.ts
+++ b/tests/behaviors/behaviors-browse-navigation.spec.ts
@@ -221,3 +221,80 @@ test.describe('#699 — the token column never wraps and never crosses the varia
     expect(geo.truncated, 'the overflow is absorbed by the ellipsis, not by spilling').toBe(true);
   });
 });
+
+test.describe('#710 — the list matches the panel height', () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test('both columns are the same height, and the list still scrolls itself', async ({ page }) => {
+    await loadBrowse(page, 'x-');           // all 585 rows — the case that blew up
+    await page.locator('.behaviors-search-results__row').first().click();
+    await page.waitForTimeout(500);
+
+    const geo = await page.evaluate(() => {
+      const list = document.getElementById('behaviors-search-results')!;
+      const panel = document.getElementById('behaviors-live')!;
+      return {
+        listH: Math.round(list.getBoundingClientRect().height),
+        panelH: Math.round(panel.getBoundingClientRect().height),
+        rows: list.querySelectorAll('.behaviors-search-results__row').length,
+        scrollsInternally: list.scrollHeight > list.clientHeight + 1,
+      };
+    });
+
+    expect(geo.rows, 'expected the full list').toBeGreaterThan(100);
+    expect(Math.abs(geo.listH - geo.panelH), 'the two columns must be the same height')
+      .toBeLessThanOrEqual(2);
+    expect(geo.scrollsInternally, 'the list must scroll inside itself, not stretch the page')
+      .toBe(true);
+    expect(geo.listH, 'a column taller than a few thousand px means the cap was lost')
+      .toBeLessThan(3000);
+  });
+
+  test('stacked, the list keeps its own cap', async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 812 });
+    await loadBrowse(page, 'x-');
+    const maxH = await page.evaluate(
+      () => document.getElementById('behaviors-search-results')!.style.maxHeight,
+    );
+    expect(maxH, 'no inline cap is applied when there is no second column to match').toBe('');
+  });
+});
+
+test.describe('#711 — the example is centred in the stage', () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  for (const [name, token, variant] of [
+    ['a block example', 'x-card', 'glass'],
+    ['an inline example', 'x-button', ''],
+  ] as const) {
+    test(`${name} sits with equal space above and below`, async ({ page }) => {
+      await loadBrowse(page, 'x-');
+
+      const geo = await page.evaluate(async ([tok, want]) => {
+        const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+        const rows = [...document.querySelectorAll('.behaviors-search-results__row')] as HTMLElement[];
+        const row = rows.find((r) => r.getAttribute('data-browse-token') === tok
+          && (!want || r.getAttribute('data-variant') === want)) || rows[0];
+        row.click();
+        await sleep(500);
+        const stage = document.getElementById('behaviors-live-stage')!;
+        const el = stage.firstElementChild as HTMLElement;
+        const sb = stage.getBoundingClientRect(), eb = el.getBoundingClientRect();
+        return {
+          tag: el.tagName.toLowerCase(),
+          above: Math.round(eb.top - sb.top),
+          below: Math.round(sb.bottom - eb.bottom),
+          elWidth: Math.round(eb.width),
+          stageWidth: Math.round(sb.width),
+        };
+      }, [token, variant] as const);
+
+      expect(Math.abs(geo.above - geo.below), `${geo.tag}: ${geo.above}px above vs ${geo.below}px below`)
+        .toBeLessThanOrEqual(2);
+      if (geo.tag === 'button') {
+        expect(geo.elWidth, 'an inline example must keep its intrinsic width')
+          .toBeLessThan(geo.stageWidth * 0.9);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## #710 — "Make the height of the left element same as right element"

The list was pinned at a fixed **24rem** (from #666) while the panel beside it is as tall as its content, so `align-items: start` left the short column stranded and the two stopped reading as one browse surface.

**Two wrong turns on the way, both caught by measuring rather than by looking:**

1. `max-height: none` + stretch let the list's own 585 rows feed the grid row's intrinsic height — **both columns grew to 32,787px**. That is the 13,000px page #664 removed, straight back.
2. Stretching *both* columns made the panel's height the row's height, while the row's height depended on the list's cap, which is measured **from the panel**. A real circle — and the browser said so, in John's error log:

```
ResizeObserver loop completed with undelivered notifications.   ×3
```

**What actually works:** only the *list* stretches (`align-self`), the panel stays at `start` so its height is its own content and the measurement is stable, and the observer writes on the next frame and only when the value changed.

Measured across five example switches: **0** new loop errors, list **1507px** = panel **1507px**, list still scrolling inside itself.

## #711 — "This element should center vertically. Too much space up here."

A block child sits at the top of the stage, so every pixel of stage height beyond the example's own piled up underneath it.

`align-content` on the block container centres it **without touching horizontal layout** — that mattered: switching the stage to flex or grid would stretch a `<button>` example to full width (`stretch`) or shrink an `<article>` one (`start`).

Measured: `<article>` 20px above / 20px below and still full width; `<button>` 39/39 and still 170px wide in a 482px stage.

## Test plan

`tests/behaviors/behaviors-browse-navigation.spec.ts` — **13/13** (9 existing + 4 new)

- [x] #710: both columns within 2px, over the **full 585-row list** — the case that blew up
- [x] #710: the list scrolls internally, and a column taller than 3000px fails the test outright
- [x] #710: stacked (375px) applies no inline cap — nothing to match
- [x] #711: block example and inline example each within 2px above vs below
- [x] #711: the inline example keeps its intrinsic width

Closes #710
Closes #711