### PR TITLE
fix(#715,#717): every showcase example is real; the selection is always first

### DIFF
--- a/data/behavior-examples.json
+++ b/data/behavior-examples.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "scripts/build-behavior-examples.mjs",
   "source": "pages/behaviors.html",
-  "count": 52,
+  "count": 146,
   "demoBlocks": 88,
   "examples": {
     "x-ripple": {
@@ -244,6 +244,382 @@
         "<div x-dropdown items=\"Profile,Settings,Billing,Team,Sign out\" label=\"Account\"></div>",
         "<div x-dropdown label=\"Opens upward\" position=\"top-start\">\n  <button type=\"button\"><img src=\"https://picsum.photos/seed/ada/28/28\" alt=\"\" width=\"28\" height=\"28\"> Ada Lovelace</button>\n  <button type=\"button\"><img src=\"https://picsum.photos/seed/grace/28/28\" alt=\"\" width=\"28\" height=\"28\"> Grace Hopper</button>\n  <button type=\"button\"><img src=\"https://picsum.photos/seed/alan/28/28\" alt=\"\" width=\"28\" height=\"28\"> Alan Turing</button>\n  <button type=\"button\">Invite someone…</button>\n</div>"
       ]
+    },
+    "x-card": {
+      "source": "<article x-card title=\"Trailhead access\" subtitle=\"Updated this morning\" elevated>\n  The north gate is open. Parking fills by 9am on weekends — the overflow lot adds\n  about ten minutes on foot.\n</article>",
+      "alternates": []
+    },
+    "x-cardbutton": {
+      "source": "<article x-cardbutton\n  title=\"Upgrade to Team\"\n  content=\"Shared workspaces, audit history and SSO.\"\n  primary=\"Start free trial\"\n  secondary=\"Compare plans\"></article>",
+      "alternates": []
+    },
+    "x-carddraggable": {
+      "source": "<article x-carddraggable title=\"Drag me\" content=\"Pick this card up and move it — the position sticks.\" constrain axis=\"both\"></article>",
+      "alternates": []
+    },
+    "x-cardexpandable": {
+      "source": "<article x-cardexpandable\n  title=\"What changed in 3.0\"\n  content=\"Composition replaced inheritance: a tag maps to a behavior function that decorates the element in place, in light DOM. There is no component base class any more, and no shadow boundary to reach through.\"\n  lines=\"2\"></article>",
+      "alternates": []
+    },
+    "x-cardfile": {
+      "source": "<article x-cardfile filename=\"quarterly-report.pdf\" file-type=\"pdf\" size=\"2.4 MB\" date=\"2026-08-14\" href=\"#\"></article>",
+      "alternates": []
+    },
+    "x-cardhero": {
+      "source": "<section x-cardhero\n  pretitle=\"Release 3.0\"\n  title=\"Zero build. Real components.\"\n  subtitle=\"Light DOM, no shadow boundaries, no class hierarchy.\"\n  cta=\"Read the guide\"\n  cta-href=\"#\"\n  height=\"320px\"></section>",
+      "alternates": []
+    },
+    "x-cardhorizontal": {
+      "source": "<article x-cardhorizontal\n  image=\"https://picsum.photos/seed/trail/320/240\"\n  image-alt=\"Pine trail at dawn\"\n  image-position=\"start\"\n  title=\"Ridge loop, 8km\"\n  subtitle=\"Moderate · 3h\"></article>",
+      "alternates": []
+    },
+    "x-cardimage": {
+      "source": "<article x-cardimage\n  src=\"https://picsum.photos/seed/harbour/480/300\"\n  alt=\"Fishing boats at the harbour wall\"\n  title=\"Harbour at first light\"\n  caption=\"Shot on the 6am walk-around.\"></article>",
+      "alternates": []
+    },
+    "x-cardlink": {
+      "source": "<article x-cardlink\n  href=\"#\"\n  title=\"Attribute naming standard\"\n  description=\"Why every attribute is kebab-case, and what breaks when it is not.\"\n  badge=\"Standard\"></article>",
+      "alternates": []
+    },
+    "x-cardminimizable": {
+      "source": "<article x-cardminimizable\n  title=\"Build log\"\n  content=\"tsc --noEmit clean. 141 regression tests passed. Packaged in 4.2s.\"></article>",
+      "alternates": []
+    },
+    "x-cardnotification": {
+      "source": "<aside x-cardnotification\n  variant=\"warning\"\n  title=\"Certificate expires in 6 days\"\n  message=\"Renew before 26 Aug or the staging domain will start failing TLS.\"\n  dismissible></aside>",
+      "alternates": []
+    },
+    "x-cardoverlay": {
+      "source": "<article x-cardoverlay\n  image=\"https://picsum.photos/seed/city/480/320\"\n  title=\"Night shift\"\n  subtitle=\"City desk, 02:00\"\n  position=\"bottom\"></article>",
+      "alternates": []
+    },
+    "x-cardportfolio": {
+      "source": "<article x-cardportfolio\n  name=\"Ada Lovelace\"\n  title=\"Principal engineer\"\n  company=\"Analytical Engines\"\n  location=\"London\"\n  cover=\"https://picsum.photos/seed/ada-cover/480/200\"></article>",
+      "alternates": []
+    },
+    "x-cardpricing": {
+      "source": "<article x-cardpricing\n  plan=\"Team\"\n  price=\"$18\"\n  period=\"per user / month\"\n  description=\"For teams that need shared history and SSO.\"\n  features=\"Unlimited projects,Audit log,SSO,Priority support\"></article>",
+      "alternates": []
+    },
+    "x-cardproduct": {
+      "source": "<article x-cardproduct\n  image=\"https://picsum.photos/seed/headphones/400/400\"\n  title=\"Field headphones\"\n  description=\"Closed-back, 32Ω, folds flat.\"\n  price=\"$149\"\n  original-price=\"$189\"></article>",
+      "alternates": []
+    },
+    "x-cardprofile": {
+      "source": "<article x-cardprofile\n  name=\"Grace Hopper\"\n  role=\"Compiler pioneer\"\n  avatar=\"https://picsum.photos/seed/grace/96/96\"\n  bio=\"Wrote the first compiler, then spent a career arguing that people should not have to write machine code.\"></article>",
+      "alternates": []
+    },
+    "x-cardstats": {
+      "source": "<article x-cardstats value=\"1,284\" label=\"Builds this month\" trend=\"up\" trend-value=\"12%\"></article>",
+      "alternates": []
+    },
+    "x-cardtestimonial": {
+      "source": "<article x-cardtestimonial\n  quote=\"We deleted the build step and shipped faster the same week.\"\n  author=\"Katherine Johnson\"\n  role=\"Platform lead\"\n  avatar=\"https://picsum.photos/seed/katherine/96/96\"\n  rating=\"5\"></article>",
+      "alternates": []
+    },
+    "x-cardvideo": {
+      "source": "<article x-cardvideo\n  src=\"/demos/sample.mp4\"\n  poster=\"https://picsum.photos/seed/screening/480/270\"\n  title=\"Behaviors in 90 seconds\"\n  description=\"What replaced the component base class, and why.\"></article>",
+      "alternates": []
+    },
+    "x-fix-card": {
+      "source": "<article x-fix-card title=\"Pinned note\" content=\"This card keeps its place while the rest of the page scrolls.\"></article>",
+      "alternates": []
+    },
+    "x-button": {
+      "source": "<button x-button variant=\"primary\" icon=\"download\" size=\"md\">Download report</button>",
+      "alternates": []
+    },
+    "x-badge": {
+      "source": "<span x-badge label=\"Beta\" variant=\"warning\" pill></span>",
+      "alternates": []
+    },
+    "x-chip": {
+      "source": "<span x-chip label=\"typescript\" icon=\"check\" dismissible></span>",
+      "alternates": []
+    },
+    "x-avatar": {
+      "source": "<div x-avatar src=\"https://picsum.photos/seed/ada/64/64\" alt=\"Ada Lovelace\" name=\"Ada Lovelace\" size=\"lg\"></div>",
+      "alternates": []
+    },
+    "x-spinner": {
+      "source": "<div x-spinner size=\"md\" variant=\"primary\" label=\"Loading results…\"></div>",
+      "alternates": []
+    },
+    "x-skeleton": {
+      "source": "<div x-skeleton variant=\"text\" lines=\"3\" animated></div>",
+      "alternates": []
+    },
+    "x-progress": {
+      "source": "<progress x-progress value=\"72\" max=\"100\" label=\"Uploading footage\" show-value></progress>",
+      "alternates": []
+    },
+    "x-progressbar": {
+      "source": "<progress x-progressbar value=\"72\" max=\"100\" label=\"Uploading footage\" show-value></progress>",
+      "alternates": []
+    },
+    "x-rating": {
+      "source": "<div x-rating value=\"4\" max=\"5\" half></div>",
+      "alternates": []
+    },
+    "x-tabs": {
+      "source": "<div x-tabs active-tab=\"0\" variant=\"underline\">\n  <section title=\"Overview\">Composition over inheritance, in light DOM.</section>\n  <section title=\"Attributes\">Every attribute is kebab-case (§31).</section>\n  <section title=\"Events\">Behaviors fire wb:&lt;name&gt;:&lt;action&gt;.</section>\n</div>",
+      "alternates": []
+    },
+    "x-header": {
+      "source": "<header x-header title=\"Field notes\" subtitle=\"Everything that happened this week\" badge=\"New\"></header>",
+      "alternates": []
+    },
+    "x-footer": {
+      "source": "<footer x-footer brand=\"Cielo Vista Software\" copyright=\"2026\" links=\"Privacy,Terms,Status\"></footer>",
+      "alternates": []
+    },
+    "x-navbar": {
+      "source": "<nav x-navbar brand=\"wb-starter\" brand-href=\"#\" tagline=\"Zero build\"></nav>",
+      "alternates": []
+    },
+    "x-hero": {
+      "source": "<div x-hero variant=\"centered\">\n  <h1>Ship the markup, not the toolchain</h1>\n  <p>Behaviors decorate real elements in light DOM — no build, no shadow roots.</p>\n</div>",
+      "alternates": []
+    },
+    "x-dialog": {
+      "source": "<button x-dialog title=\"Delete branch?\" content=\"fix/706-dropdown will be removed. This cannot be undone.\" size=\"md\">Delete branch…</button>",
+      "alternates": []
+    },
+    "x-drawer": {
+      "source": "<button x-drawer title=\"Filters\" content=\"Status, owner, label and date range live here.\" position=\"end\" width=\"320px\">Open filters</button>",
+      "alternates": []
+    },
+    "x-accordion": {
+      "source": "<div x-accordion>\n  <details summary=\"How do behaviors attach?\"><p>WB scans for x-* attributes and calls the matching behavior function on the element, in place.</p></details>\n  <details summary=\"Is there a shadow root?\"><p>No. Light DOM only — you can style and query everything.</p></details>\n  <details summary=\"What about a build step?\"><p>There isn't one. The browser loads the modules directly.</p></details>\n</div>",
+      "alternates": []
+    },
+    "x-input": {
+      "source": "<div x-input label=\"Repository\" placeholder=\"owner/name\" name=\"repo\" input-type=\"text\"></div>",
+      "alternates": []
+    },
+    "x-textarea": {
+      "source": "<div x-textarea label=\"Release notes\" placeholder=\"What changed?\" name=\"notes\" rows=\"4\"></div>",
+      "alternates": []
+    },
+    "x-select": {
+      "source": "<div x-select label=\"Branch\" name=\"branch\" options=\"main,develop,fix/706-dropdown\" value=\"main\"></div>",
+      "alternates": []
+    },
+    "x-checkbox": {
+      "source": "<div x-checkbox label=\"Run the full suite before pushing\" name=\"full-suite\" checked></div>",
+      "alternates": []
+    },
+    "x-switch": {
+      "source": "<div x-switch label=\"Publish to staging on merge\" name=\"auto-deploy\" checked></div>",
+      "alternates": []
+    },
+    "x-otp": {
+      "source": "<div x-otp length=\"6\"></div>",
+      "alternates": []
+    },
+    "x-counter": {
+      "source": "<textarea x-counter max=\"280\" warning=\"40\" placeholder=\"What are you shipping?\"></textarea>",
+      "alternates": []
+    },
+    "x-form": {
+      "source": "<form x-form validate ajax>\n  <label>Email <input type=\"email\" name=\"email\" required placeholder=\"you@example.com\"></label>\n  <label>Message <textarea name=\"message\" rows=\"3\" required></textarea></label>\n  <button type=\"submit\">Send</button>\n</form>",
+      "alternates": []
+    },
+    "x-formrow": {
+      "source": "<div x-formrow inline>\n  <input type=\"text\" placeholder=\"City\">\n  <input type=\"text\" placeholder=\"ZIP code\">\n</div>",
+      "alternates": []
+    },
+    "x-fieldset": {
+      "source": "<fieldset x-fieldset collapsible>\n  <legend>Notification settings</legend>\n  <label><input type=\"checkbox\" checked> Build finished</label>\n  <label><input type=\"checkbox\"> Nightly audit</label>\n</fieldset>",
+      "alternates": []
+    },
+    "x-inputgroup": {
+      "source": "<div x-inputgroup>\n  <span>https://</span>\n  <input type=\"text\" placeholder=\"your-site.io\">\n  <button type=\"button\">Check</button>\n</div>",
+      "alternates": []
+    },
+    "x-floatinglabel": {
+      "source": "<div x-floatinglabel>\n  <input type=\"text\" id=\"wb-ex-floating\" placeholder=\" \">\n  <label for=\"wb-ex-floating\">Project name</label>\n</div>",
+      "alternates": []
+    },
+    "x-searchfield": {
+      "source": "<input x-searchfield type=\"search\" placeholder=\"Search 143 behaviors…\">",
+      "alternates": []
+    },
+    "x-slider": {
+      "source": "<input x-slider type=\"range\" min=\"0\" max=\"100\" value=\"35\">",
+      "alternates": []
+    },
+    "x-file": {
+      "source": "<input x-file type=\"file\" accept=\"image/*\">",
+      "alternates": []
+    },
+    "x-label": {
+      "source": "<label x-label required label-position=\"top\">Deploy key</label>",
+      "alternates": []
+    },
+    "x-autocomplete": {
+      "source": "<input x-autocomplete items=\"main,develop,release/3.0,fix/706-dropdown,docs/behaviors\" placeholder=\"Find a branch…\">",
+      "alternates": []
+    },
+    "x-autosize": {
+      "source": "<textarea x-autosize rows=\"1\" placeholder=\"This grows as you type — try three or four lines.\"></textarea>",
+      "alternates": []
+    },
+    "x-control": {
+      "source": "<div x-control label=\"Threshold\">\n  <input type=\"range\" min=\"0\" max=\"100\" value=\"60\">\n</div>",
+      "alternates": []
+    },
+    "x-flex": {
+      "source": "<div x-flex gap=\"1rem\">\n  <div>First</div><div>Second</div><div>Third</div>\n</div>",
+      "alternates": []
+    },
+    "x-stack": {
+      "source": "<div x-stack gap=\"0.75rem\" pad=\"1rem\" radius=\"8px\">\n  <div>Queued</div><div>Running</div><div>Passed</div>\n</div>",
+      "alternates": []
+    },
+    "x-cluster": {
+      "source": "<div x-cluster gap=\"0.5rem\">\n  <span>typescript</span><span>playwright</span><span>light-dom</span><span>no-build</span>\n</div>",
+      "alternates": []
+    },
+    "x-masonry": {
+      "source": "<div x-masonry columns=\"3\" gap=\"0.75rem\">\n  <img src=\"https://picsum.photos/seed/m1/300/220\" alt=\"\">\n  <img src=\"https://picsum.photos/seed/m2/300/320\" alt=\"\">\n  <img src=\"https://picsum.photos/seed/m3/300/180\" alt=\"\">\n  <img src=\"https://picsum.photos/seed/m4/300/260\" alt=\"\">\n</div>",
+      "alternates": []
+    },
+    "x-ratio": {
+      "source": "<div x-ratio ratio=\"16:9\">\n  <img src=\"https://picsum.photos/seed/wide/640/360\" alt=\"Coastline from the air\">\n</div>",
+      "alternates": []
+    },
+    "x-span": {
+      "source": "<span x-span variant=\"muted\">Last run 4 minutes ago</span>",
+      "alternates": []
+    },
+    "x-repeater": {
+      "source": "<div x-repeater>\n  <div>Row template — add and remove copies of this block.</div>\n</div>",
+      "alternates": []
+    },
+    "x-demo": {
+      "source": "<div x-demo columns=\"2\">\n  <button>One</button>\n  <button>Two</button>\n</div>",
+      "alternates": []
+    },
+    "x-audio": {
+      "source": "<div x-audio src=\"/demos/sample.wav\" volume=\"0.8\"></div>",
+      "alternates": []
+    },
+    "x-video": {
+      "source": "<video x-video src=\"/demos/sample.mp4\" poster=\"https://picsum.photos/seed/screening/640/360\" controls></video>",
+      "alternates": []
+    },
+    "x-img": {
+      "source": "<img x-img src=\"https://picsum.photos/seed/lens/480/320\" alt=\"Prime lens on a wooden desk\">",
+      "alternates": []
+    },
+    "x-figure": {
+      "source": "<figure x-figure>\n  <img src=\"https://picsum.photos/seed/bridge/480/300\" alt=\"Suspension bridge in fog\">\n  <figcaption>The 6am crossing, before the fog lifted.</figcaption>\n</figure>",
+      "alternates": []
+    },
+    "x-vimeo": {
+      "source": "<div x-vimeo video-id=\"76979871\"></div>",
+      "alternates": []
+    },
+    "x-pre": {
+      "source": "<pre x-pre>npm run test:compliance\n  7591 passed\n     82 failed</pre>",
+      "alternates": []
+    },
+    "x-mark": {
+      "source": "<p>Search matched <mark x-mark>light DOM</mark> in 12 documents.</p>",
+      "alternates": []
+    },
+    "x-typewriter": {
+      "source": "<p x-typewriter speed=\"45\">Zero build. Real components. Light DOM only.</p>",
+      "alternates": []
+    },
+    "x-mdhtml": {
+      "source": "<div x-mdhtml src=\"/docs/behaviors/dropdown.md\"></div>",
+      "alternates": []
+    },
+    "x-notes": {
+      "source": "<aside x-notes position=\"end\" default-width=\"280px\">\n  <p>Notes stay pinned beside the content while you scroll.</p>\n</aside>",
+      "alternates": []
+    },
+    "x-error": {
+      "source": "<div x-error>Build failed: 2 of 13 catalog-integrity checks.</div>",
+      "alternates": []
+    },
+    "x-help": {
+      "source": "<span x-help>Deploy key</span>",
+      "alternates": []
+    },
+    "x-collapse": {
+      "source": "<div x-collapse heading=\"Environment\" expanded>\n  <p>Node 24.13, Chrome 139, Windows 11.</p>\n</div>",
+      "alternates": []
+    },
+    "x-copybutton": {
+      "source": "<button x-copybutton copy-target=\"#wb-ex-copy-source\">Copy command</button>\n<code id=\"wb-ex-copy-source\">npm run test:compliance</code>",
+      "alternates": []
+    },
+    "x-notify": {
+      "source": "<button x-notify message=\"Deploy finished — staging is live.\" variant=\"success\">Notify me</button>",
+      "alternates": []
+    },
+    "x-toggle": {
+      "source": "<button x-toggle target=\"#wb-ex-toggle-panel\">Show details</button>\n<div id=\"wb-ex-toggle-panel\">The panel this button toggles.</div>",
+      "alternates": []
+    },
+    "x-globe": {
+      "source": "<div x-globe></div>",
+      "alternates": []
+    },
+    "x-themecontrol": {
+      "source": "<div x-themecontrol></div>",
+      "alternates": []
+    },
+    "x-codecontrol": {
+      "source": "<div x-codecontrol></div>",
+      "alternates": []
+    },
+    "x-tags": {
+      "source": "<input x-tags value=\"light-dom,no-build,playwright\" placeholder=\"Add a tag…\">",
+      "alternates": []
+    },
+    "x-article": {
+      "source": "<article x-article title=\"Ridge loop, 8km\" subtitle=\"Moderate · 3h\" author=\"Ada Lovelace\" date=\"2026-08-20\" category=\"Trails\">\n  The north gate is open and the creek crossing is dry. Parking fills by 9am on\n  weekends — the overflow lot adds about ten minutes on foot.\n</article>",
+      "alternates": []
+    },
+    "x-articles": {
+      "source": "<section x-articles layout=\"grid\" columns=\"2\" limit=\"4\">\n  <article title=\"Ridge loop, 8km\">Moderate, three hours, dry crossing.</article>\n  <article title=\"Harbour wall at dawn\">Flat, two hours, best before the fog lifts.</article>\n  <article title=\"Pine gap traverse\">Hard, six hours, carry water.</article>\n  <article title=\"Old quarry circuit\">Easy, ninety minutes, good in rain.</article>\n</section>",
+      "alternates": []
+    },
+    "x-draggable": {
+      "source": "<div x-draggable axis=\"both\">Drag me anywhere in the stage.</div>",
+      "alternates": []
+    },
+    "x-drawer-layout": {
+      "source": "<aside x-drawer-layout position=\"start\" width=\"220px\" min-width=\"64px\">\n  <nav><a href=\"#\">Overview</a><a href=\"#\">Runs</a><a href=\"#\">Settings</a></nav>\n</aside>",
+      "alternates": []
+    },
+    "x-move": {
+      "source": "<button x-move distance=\"120px\" duration=\"0.6s\">Move me</button>",
+      "alternates": []
+    },
+    "x-release": {
+      "source": "<div x-release version=\"3.0.48\" date=\"2026-08-20\">\n  143 behavior docs, curated showcase examples, dropdown fixes.\n</div>",
+      "alternates": []
+    },
+    "x-resizable": {
+      "source": "<div x-resizable handles=\"se\">\n  Grab the corner and resize this panel.\n</div>",
+      "alternates": []
+    },
+    "x-scrollalong": {
+      "source": "<aside x-scrollalong offset=\"16\">\n  Keeps pace with the page as you scroll.\n</aside>",
+      "alternates": []
+    },
+    "x-stagelight": {
+      "source": "<div x-stagelight variant=\"spotlight\" color=\"#f59e0b\" intensity=\"0.5\" size=\"360px\">\n  The spotlight follows the pointer across this panel.\n</div>",
+      "alternates": []
+    },
+    "x-sticky": {
+      "source": "<div x-sticky offset=\"0\" stuck-class=\"is-stuck\">\n  Sticks to the top of its scroll container once you pass it.\n</div>",
+      "alternates": []
     }
   }
 }

--- a/index.html
+++ b/index.html
@@ -27,15 +27,15 @@
   <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
 
   <!-- Layer 1: Foundation (render-blocking, already highest priority — no preload needed) -->
-  <link rel="stylesheet" href="src/styles/normalize.css?v=644df89">
-  <link rel="stylesheet" href="src/styles/themes.css?v=644df89">
-  <link rel="stylesheet" href="src/styles/site.css?v=644df89">
-  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=644df89">
-  <link rel="modulepreload" href="src/core/wb.js?v=644df89">
-  <link rel="modulepreload" href="src/core/site-engine.js?v=644df89">
+  <link rel="stylesheet" href="src/styles/normalize.css?v=794116a">
+  <link rel="stylesheet" href="src/styles/themes.css?v=794116a">
+  <link rel="stylesheet" href="src/styles/site.css?v=794116a">
+  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=794116a">
+  <link rel="modulepreload" href="src/core/wb.js?v=794116a">
+  <link rel="modulepreload" href="src/core/site-engine.js?v=794116a">
 
   <!-- Page Transitions CSS -->
-  <link rel="stylesheet" href="src/styles/transitions.css?v=644df89">
+  <link rel="stylesheet" href="src/styles/transitions.css?v=794116a">
   <!-- Navbar CSS already loads via site.css's own @import — no separate link needed. -->
 
   <!-- Fonts -->
@@ -92,9 +92,9 @@
   </template>
 
   <!-- Premium Navbar Scroll Effect -->
-  <script src="src/lib/premium-navbar.js?v=644df89"></script>
+  <script src="src/lib/premium-navbar.js?v=794116a"></script>
 
   <!-- Main Application Bootstrap -->
-  <script type="module" src="./src/main.js?v=644df89"></script>
+  <script type="module" src="./src/main.js?v=794116a"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wb-starter",
-  "version": "3.0.48",
+  "version": "3.0.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wb-starter",
-      "version": "3.0.48",
+      "version": "3.0.49",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wb-starter",
-  "version": "3.0.48",
+  "version": "3.0.49",
   "type": "module",
   "description": "Modern website starter kit powered by WB Behaviors",
   "main": "index.html",

--- a/pages/behaviors.html
+++ b/pages/behaviors.html
@@ -365,6 +365,9 @@
       });
       if (!q) totalRowCount = rendered;
       resultsEl.appendChild(frag);
+      // #717: a new filter is a new set of rows -- the trailing room has to be
+      // recomputed for THIS list, not the one it replaced.
+      if (typeof syncTailRoom === 'function') syncTailRoom();
     }
 
     // Which hit does the reader actually mean? Typing "button" matched
@@ -497,8 +500,60 @@
         // Only write on a real change -- an unconditional write re-triggers the
         // observer every frame for no reason.
         if (resultsEl.style.maxHeight !== next) resultsEl.style.maxHeight = next;
+        syncTailRoom();
       });
     }
+    // #717 -- John: "When using the down or up button the current selection must
+    // be the first one." selectRow() sets scrollTop = rowTop and the browser
+    // clamps at scrollHeight - clientHeight, so for the LAST screenful of rows
+    // there is nothing below them to scroll into view: measured, row 48 of 49
+    // sat 1134px down instead of 0, drifting further the closer to the end.
+    // Trailing space equal to (viewport - last row) puts every row within reach
+    // of the top. Only while the list actually scrolls -- a short list gains
+    // nothing from it and would just grow a scrollbar.
+    // The row the keyboard last pinned to the top. Padding changes move the
+    // scroll range under it, so the alignment has to be re-applied afterwards.
+    let alignedRow = null;
+
+    function realignAligned() {
+      if (!alignedRow || !alignedRow.isConnected) return;
+      const top = alignedRow.offsetTop - resultsEl.offsetTop;
+      if (Math.round(resultsEl.scrollTop) !== Math.round(top)) resultsEl.scrollTop = top;
+    }
+
+    function syncTailRoom() {
+      const rows = resultsEl.querySelectorAll('.behaviors-search-results__row');
+      const last = rows[rows.length - 1];
+      if (!last) { resultsEl.style.paddingBottom = ''; return; }
+      const current = parseFloat(resultsEl.style.paddingBottom) || 0;
+      const contentHeight = resultsEl.scrollHeight - current;
+      if (contentHeight <= resultsEl.clientHeight + 1) {
+        if (current) resultsEl.style.paddingBottom = '';
+        return;
+      }
+      const room = Math.max(0, Math.round(resultsEl.clientHeight - last.offsetHeight));
+      const next = room + 'px';
+      if (resultsEl.style.paddingBottom !== next) resultsEl.style.paddingBottom = next;
+
+      // Then CHECK it, rather than trusting the arithmetic: rows differ in
+      // height (a long token wraps), and the list's own border and row gaps are
+      // not in that subtraction. Measured with the estimate alone, the last row
+      // still landed 4px short and row 47 18px short. Top up by exactly the
+      // shortfall -- once the last row can reach the top, so can every row
+      // above it, since each one needs less scroll than the last.
+      const lastTop = last.offsetTop - resultsEl.offsetTop;
+      const maxScroll = resultsEl.scrollHeight - resultsEl.clientHeight;
+      if (maxScroll < lastTop) {
+        resultsEl.style.paddingBottom = (room + Math.ceil(lastTop - maxScroll)) + 'px';
+      }
+
+      // #717: every arrow press renders a different example, which resizes the
+      // panel, which resizes the list, which lands here -- AFTER selectRow()
+      // already set scrollTop. Measured: ArrowUp drifted 18px on a 49-row list
+      // and 99px on the full 585. Re-pin the row the keyboard aligned.
+      realignAligned();
+    }
+
     // The panel's height drives the list's; the list never drives the panel's,
     // so this cannot feed back on itself.
     new ResizeObserver(syncListHeight).observe(liveEl);
@@ -1415,6 +1470,7 @@
       const rowTop = row.offsetTop - resultsEl.offsetTop;
       const rowBottom = rowTop + row.offsetHeight;
       if (align) {
+        alignedRow = row;
         // #687 -- John: "I would like all down arrow activity to align with the
         // top every time it's pressed". Minimal scrolling left the selection
         // pinned to the BOTTOM edge once it got there, so arrowing read as "the

--- a/project-index.html
+++ b/project-index.html
@@ -7,8 +7,8 @@
     <title>Project Index</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
-    <link rel="stylesheet" href="src/styles/themes.css?v=644df89">
-    <link rel="stylesheet" href="src/styles/site.css?v=644df89">
+    <link rel="stylesheet" href="src/styles/themes.css?v=794116a">
+    <link rel="stylesheet" href="src/styles/site.css?v=794116a">
     <script type="module">
       import WB from './src/core/wb.js';
       WB.init({ autoInject: true });

--- a/scripts/seed-behavior-examples.mjs
+++ b/scripts/seed-behavior-examples.mjs
@@ -1,0 +1,445 @@
+/**
+ * seed-behavior-examples.mjs (#715)
+ *
+ * Adds curated examples to data/behavior-examples.json for behaviors that would
+ * otherwise render the generated placeholder — `<article variant="flat">Example
+ * article content</article>`. The schema supplies the tag and the attribute; the
+ * BODY was filler, and for a container-shaped behavior filler is exactly why
+ * there is nothing to look at (the x-dropdown empty menu, #701).
+ *
+ * Every entry below is written by hand against that behavior's own schema
+ * properties (src/wb-models/<name>.schema.json), in kebab-case per §31, with
+ * real content — names, prices, labels — not lorem.
+ *
+ * NEVER overwrites an existing catalogue entry: the curated ones already there
+ * are the source of truth (#666).
+ *
+ * Usage:
+ *   node scripts/seed-behavior-examples.mjs           # merge in the missing ones
+ *   node scripts/seed-behavior-examples.mjs --check   # report, write nothing
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), '..');
+const CATALOGUE = path.join(ROOT, 'data', 'behavior-examples.json');
+const CHECK = process.argv.includes('--check');
+
+const img = (seed, w, h) => `https://picsum.photos/seed/${seed}/${w}/${h}`;
+
+/** token -> markup. Attribute names come from each behavior's schema. */
+export const EXAMPLES = {
+  // ── Card family ────────────────────────────────────────────────────────────
+  'x-card': `<article x-card title="Trailhead access" subtitle="Updated this morning" elevated>
+  The north gate is open. Parking fills by 9am on weekends — the overflow lot adds
+  about ten minutes on foot.
+</article>`,
+
+  'x-cardbutton': `<article x-cardbutton
+  title="Upgrade to Team"
+  content="Shared workspaces, audit history and SSO."
+  primary="Start free trial"
+  secondary="Compare plans"></article>`,
+
+  'x-carddraggable': `<article x-carddraggable title="Drag me" content="Pick this card up and move it — the position sticks." constrain axis="both"></article>`,
+
+  'x-cardexpandable': `<article x-cardexpandable
+  title="What changed in 3.0"
+  content="Composition replaced inheritance: a tag maps to a behavior function that decorates the element in place, in light DOM. There is no component base class any more, and no shadow boundary to reach through."
+  lines="2"></article>`,
+
+  'x-cardfile': `<article x-cardfile filename="quarterly-report.pdf" file-type="pdf" size="2.4 MB" date="2026-08-14" href="#"></article>`,
+
+  'x-cardhero': `<section x-cardhero
+  pretitle="Release 3.0"
+  title="Zero build. Real components."
+  subtitle="Light DOM, no shadow boundaries, no class hierarchy."
+  cta="Read the guide"
+  cta-href="#"
+  height="320px"></section>`,
+
+  'x-cardhorizontal': `<article x-cardhorizontal
+  image="${img('trail', 320, 240)}"
+  image-alt="Pine trail at dawn"
+  image-position="start"
+  title="Ridge loop, 8km"
+  subtitle="Moderate · 3h"></article>`,
+
+  'x-cardimage': `<article x-cardimage
+  src="${img('harbour', 480, 300)}"
+  alt="Fishing boats at the harbour wall"
+  title="Harbour at first light"
+  caption="Shot on the 6am walk-around."></article>`,
+
+  'x-cardlink': `<article x-cardlink
+  href="#"
+  title="Attribute naming standard"
+  description="Why every attribute is kebab-case, and what breaks when it is not."
+  badge="Standard"></article>`,
+
+  'x-cardminimizable': `<article x-cardminimizable
+  title="Build log"
+  content="tsc --noEmit clean. 141 regression tests passed. Packaged in 4.2s."></article>`,
+
+  'x-cardnotification': `<aside x-cardnotification
+  variant="warning"
+  title="Certificate expires in 6 days"
+  message="Renew before 26 Aug or the staging domain will start failing TLS."
+  dismissible></aside>`,
+
+  'x-cardoverlay': `<article x-cardoverlay
+  image="${img('city', 480, 320)}"
+  title="Night shift"
+  subtitle="City desk, 02:00"
+  position="bottom"></article>`,
+
+  'x-cardportfolio': `<article x-cardportfolio
+  name="Ada Lovelace"
+  title="Principal engineer"
+  company="Analytical Engines"
+  location="London"
+  cover="${img('ada-cover', 480, 200)}"></article>`,
+
+  'x-cardpricing': `<article x-cardpricing
+  plan="Team"
+  price="$18"
+  period="per user / month"
+  description="For teams that need shared history and SSO."
+  features="Unlimited projects,Audit log,SSO,Priority support"></article>`,
+
+  'x-cardproduct': `<article x-cardproduct
+  image="${img('headphones', 400, 400)}"
+  title="Field headphones"
+  description="Closed-back, 32Ω, folds flat."
+  price="$149"
+  original-price="$189"></article>`,
+
+  'x-cardprofile': `<article x-cardprofile
+  name="Grace Hopper"
+  role="Compiler pioneer"
+  avatar="${img('grace', 96, 96)}"
+  bio="Wrote the first compiler, then spent a career arguing that people should not have to write machine code."></article>`,
+
+  'x-cardstats': `<article x-cardstats value="1,284" label="Builds this month" trend="up" trend-value="12%"></article>`,
+
+  'x-cardtestimonial': `<article x-cardtestimonial
+  quote="We deleted the build step and shipped faster the same week."
+  author="Katherine Johnson"
+  role="Platform lead"
+  avatar="${img('katherine', 96, 96)}"
+  rating="5"></article>`,
+
+  'x-cardvideo': `<article x-cardvideo
+  src="/demos/sample.mp4"
+  poster="${img('screening', 480, 270)}"
+  title="Behaviors in 90 seconds"
+  description="What replaced the component base class, and why."></article>`,
+
+  'x-fix-card': `<article x-fix-card title="Pinned note" content="This card keeps its place while the rest of the page scrolls."></article>`,
+
+  // ── Core UI ────────────────────────────────────────────────────────────────
+  'x-button': `<button x-button variant="primary" icon="download" size="md">Download report</button>`,
+
+  'x-badge': `<span x-badge label="Beta" variant="warning" pill></span>`,
+
+  'x-chip': `<span x-chip label="typescript" icon="check" dismissible></span>`,
+
+  'x-avatar': `<div x-avatar src="${img('ada', 64, 64)}" alt="Ada Lovelace" name="Ada Lovelace" size="lg"></div>`,
+
+  'x-spinner': `<div x-spinner size="md" variant="primary" label="Loading results…"></div>`,
+
+  'x-skeleton': `<div x-skeleton variant="text" lines="3" animated></div>`,
+
+  'x-progress': `<progress x-progress value="72" max="100" label="Uploading footage" show-value></progress>`,
+  'x-progressbar': `<progress x-progressbar value="72" max="100" label="Uploading footage" show-value></progress>`,
+
+  'x-rating': `<div x-rating value="4" max="5" half></div>`,
+
+  'x-tabs': `<div x-tabs active-tab="0" variant="underline">
+  <section title="Overview">Composition over inheritance, in light DOM.</section>
+  <section title="Attributes">Every attribute is kebab-case (§31).</section>
+  <section title="Events">Behaviors fire wb:&lt;name&gt;:&lt;action&gt;.</section>
+</div>`,
+
+  'x-header': `<header x-header title="Field notes" subtitle="Everything that happened this week" badge="New"></header>`,
+
+  'x-footer': `<footer x-footer brand="Cielo Vista Software" copyright="2026" links="Privacy,Terms,Status"></footer>`,
+
+  'x-navbar': `<nav x-navbar brand="wb-starter" brand-href="#" tagline="Zero build"></nav>`,
+
+  'x-hero': `<div x-hero variant="centered">
+  <h1>Ship the markup, not the toolchain</h1>
+  <p>Behaviors decorate real elements in light DOM — no build, no shadow roots.</p>
+</div>`,
+
+  'x-dialog': `<button x-dialog title="Delete branch?" content="fix/706-dropdown will be removed. This cannot be undone." size="md">Delete branch…</button>`,
+
+  'x-drawer': `<button x-drawer title="Filters" content="Status, owner, label and date range live here." position="end" width="320px">Open filters</button>`,
+
+  'x-accordion': `<div x-accordion>
+  <details summary="How do behaviors attach?"><p>WB scans for x-* attributes and calls the matching behavior function on the element, in place.</p></details>
+  <details summary="Is there a shadow root?"><p>No. Light DOM only — you can style and query everything.</p></details>
+  <details summary="What about a build step?"><p>There isn't one. The browser loads the modules directly.</p></details>
+</div>`,
+
+  // ── Forms ──────────────────────────────────────────────────────────────────
+  'x-input': `<div x-input label="Repository" placeholder="owner/name" name="repo" input-type="text"></div>`,
+
+  'x-textarea': `<div x-textarea label="Release notes" placeholder="What changed?" name="notes" rows="4"></div>`,
+
+  'x-select': `<div x-select label="Branch" name="branch" options="main,develop,fix/706-dropdown" value="main"></div>`,
+
+  'x-checkbox': `<div x-checkbox label="Run the full suite before pushing" name="full-suite" checked></div>`,
+
+  'x-switch': `<div x-switch label="Publish to staging on merge" name="auto-deploy" checked></div>`,
+
+  'x-otp': `<div x-otp length="6"></div>`,
+
+  'x-counter': `<textarea x-counter max="280" warning="40" placeholder="What are you shipping?"></textarea>`,
+
+  'x-form': `<form x-form validate ajax>
+  <label>Email <input type="email" name="email" required placeholder="you@example.com"></label>
+  <label>Message <textarea name="message" rows="3" required></textarea></label>
+  <button type="submit">Send</button>
+</form>`,
+
+  'x-formrow': `<div x-formrow inline>
+  <input type="text" placeholder="City">
+  <input type="text" placeholder="ZIP code">
+</div>`,
+
+  'x-fieldset': `<fieldset x-fieldset collapsible>
+  <legend>Notification settings</legend>
+  <label><input type="checkbox" checked> Build finished</label>
+  <label><input type="checkbox"> Nightly audit</label>
+</fieldset>`,
+
+  'x-inputgroup': `<div x-inputgroup>
+  <span>https://</span>
+  <input type="text" placeholder="your-site.io">
+  <button type="button">Check</button>
+</div>`,
+
+  'x-floatinglabel': `<div x-floatinglabel>
+  <input type="text" id="wb-ex-floating" placeholder=" ">
+  <label for="wb-ex-floating">Project name</label>
+</div>`,
+
+  'x-searchfield': `<input x-searchfield type="search" placeholder="Search 143 behaviors…">`,
+
+  'x-slider': `<input x-slider type="range" min="0" max="100" value="35">`,
+
+  'x-file': `<input x-file type="file" accept="image/*">`,
+
+  'x-label': `<label x-label required label-position="top">Deploy key</label>`,
+
+  'x-autocomplete': `<input x-autocomplete items="main,develop,release/3.0,fix/706-dropdown,docs/behaviors" placeholder="Find a branch…">`,
+
+  'x-autosize': `<textarea x-autosize rows="1" placeholder="This grows as you type — try three or four lines."></textarea>`,
+
+  'x-control': `<div x-control label="Threshold">
+  <input type="range" min="0" max="100" value="60">
+</div>`,
+
+  // ── Layout ─────────────────────────────────────────────────────────────────
+  'x-flex': `<div x-flex gap="1rem">
+  <div>First</div><div>Second</div><div>Third</div>
+</div>`,
+
+  'x-stack': `<div x-stack gap="0.75rem" pad="1rem" radius="8px">
+  <div>Queued</div><div>Running</div><div>Passed</div>
+</div>`,
+
+  'x-cluster': `<div x-cluster gap="0.5rem">
+  <span>typescript</span><span>playwright</span><span>light-dom</span><span>no-build</span>
+</div>`,
+
+  'x-masonry': `<div x-masonry columns="3" gap="0.75rem">
+  <img src="${img('m1', 300, 220)}" alt="">
+  <img src="${img('m2', 300, 320)}" alt="">
+  <img src="${img('m3', 300, 180)}" alt="">
+  <img src="${img('m4', 300, 260)}" alt="">
+</div>`,
+
+  'x-ratio': `<div x-ratio ratio="16:9">
+  <img src="${img('wide', 640, 360)}" alt="Coastline from the air">
+</div>`,
+
+  'x-span': `<span x-span variant="muted">Last run 4 minutes ago</span>`,
+
+  'x-repeater': `<div x-repeater>
+  <div>Row template — add and remove copies of this block.</div>
+</div>`,
+
+  'x-demo': `<div x-demo columns="2">
+  <button>One</button>
+  <button>Two</button>
+</div>`,
+
+  // ── Media ──────────────────────────────────────────────────────────────────
+  'x-audio': `<div x-audio src="/demos/sample.wav" volume="0.8"></div>`,
+
+  'x-video': `<video x-video src="/demos/sample.mp4" poster="${img('screening', 640, 360)}" controls></video>`,
+
+  'x-img': `<img x-img src="${img('lens', 480, 320)}" alt="Prime lens on a wooden desk">`,
+
+  'x-image': `<img x-image src="${img('lens', 480, 320)}" alt="Prime lens on a wooden desk" lazy zoomable>`,
+
+  'x-figure': `<figure x-figure>
+  <img src="${img('bridge', 480, 300)}" alt="Suspension bridge in fog">
+  <figcaption>The 6am crossing, before the fog lifted.</figcaption>
+</figure>`,
+
+  'x-gallery': `<div x-gallery columns="3">
+  <img src="${img('g1', 240, 240)}" alt="">
+  <img src="${img('g2', 240, 240)}" alt="">
+  <img src="${img('g3', 240, 240)}" alt="">
+</div>`,
+
+  'x-vimeo': `<div x-vimeo video-id="76979871"></div>`,
+
+  // ── Text & code ────────────────────────────────────────────────────────────
+  'x-pre': `<pre x-pre>npm run test:compliance
+  7591 passed
+     82 failed</pre>`,
+
+  'x-kbd': `<span x-kbd>Ctrl</span> <span x-kbd>Shift</span> <span x-kbd>P</span>`,
+
+  'x-mark': `<p>Search matched <mark x-mark>light DOM</mark> in 12 documents.</p>`,
+
+  'x-truncate': `<p x-truncate lines="2">Composition replaced inheritance in 3.0: a tag maps to a behavior function that decorates the element in place, in light DOM. There is no component base class any more, and no shadow boundary to reach through, so everything stays styleable and queryable.</p>`,
+
+  'x-typewriter': `<p x-typewriter speed="45">Zero build. Real components. Light DOM only.</p>`,
+
+  'x-mdhtml': `<div x-mdhtml src="/docs/behaviors/dropdown.md"></div>`,
+
+  'x-notes': `<aside x-notes position="end" default-width="280px">
+  <p>Notes stay pinned beside the content while you scroll.</p>
+</aside>`,
+
+  'x-error': `<div x-error>Build failed: 2 of 13 catalog-integrity checks.</div>`,
+
+  'x-help': `<span x-help>Deploy key</span>`,
+
+  'x-collapse': `<div x-collapse heading="Environment" expanded>
+  <p>Node 24.13, Chrome 139, Windows 11.</p>
+</div>`,
+
+  'x-steps': `<div x-steps current="1">
+  <div>Clone</div><div>Install</div><div>Run</div>
+</div>`,
+
+  'x-breadcrumb': `<nav x-breadcrumb>
+  <a href="#">Docs</a>
+  <a href="#">Behaviors</a>
+  <span>Dropdown</span>
+</nav>`,
+
+  'x-pagination': `<nav x-pagination total="12" current="3"></nav>`,
+
+  'x-timeline': `<div x-timeline>
+  <div>3.0.44 — behaviors browse panel</div>
+  <div>3.0.46 — dropdown examples</div>
+  <div>3.0.48 — 143 behavior docs</div>
+</div>`,
+
+  // ── Utilities & effects ────────────────────────────────────────────────────
+  'x-copybutton': `<button x-copybutton copy-target="#wb-ex-copy-source">Copy command</button>
+<code id="wb-ex-copy-source">npm run test:compliance</code>`,
+
+  'x-clock': `<span x-clock format="HH:mm:ss"></span>`,
+
+  'x-countdown': `<span x-countdown to="2026-12-31T23:59:59"></span>`,
+
+  'x-relativetime': `<time x-relativetime datetime="2026-08-20T09:15:00Z"></time>`,
+
+  'x-share': `<button x-share title="wb-starter" text="Zero build. Real components." url="https://github.com/CieloVistaSoftware/wb-starter">Share</button>`,
+
+  'x-print': `<button x-print>Print this page</button>`,
+
+  'x-fullscreen': `<button x-fullscreen target="#wb-ex-fullscreen-stage">Go fullscreen</button>
+<div id="wb-ex-fullscreen-stage">This panel is what expands.</div>`,
+
+  'x-confirm': `<button x-confirm message="Delete this branch? This cannot be undone.">Delete branch</button>`,
+
+  'x-prompt': `<button x-prompt message="Name the new branch" default-value="fix/">New branch…</button>`,
+
+  'x-notify': `<button x-notify message="Deploy finished — staging is live." variant="success">Notify me</button>`,
+
+  'x-popover': `<button x-popover content="Runs the full compliance suite. Takes about 12 minutes.">What does this do?</button>`,
+
+  'x-toggle': `<button x-toggle target="#wb-ex-toggle-panel">Show details</button>
+<div id="wb-ex-toggle-panel">The panel this button toggles.</div>`,
+
+  'x-globe': `<div x-globe></div>`,
+
+  'x-themecontrol': `<div x-themecontrol></div>`,
+
+  'x-codecontrol': `<div x-codecontrol></div>`,
+
+  // ── Positional / motion ────────────────────────────────────────────────────
+  'x-article': `<article x-article title="Ridge loop, 8km" subtitle="Moderate · 3h" author="Ada Lovelace" date="2026-08-20" category="Trails">
+  The north gate is open and the creek crossing is dry. Parking fills by 9am on
+  weekends — the overflow lot adds about ten minutes on foot.
+</article>`,
+
+  'x-articles': `<section x-articles layout="grid" columns="2" limit="4">
+  <article title="Ridge loop, 8km">Moderate, three hours, dry crossing.</article>
+  <article title="Harbour wall at dawn">Flat, two hours, best before the fog lifts.</article>
+  <article title="Pine gap traverse">Hard, six hours, carry water.</article>
+  <article title="Old quarry circuit">Easy, ninety minutes, good in rain.</article>
+</section>`,
+
+  'x-draggable': `<div x-draggable axis="both">Drag me anywhere in the stage.</div>`,
+
+  'x-drawer-layout': `<aside x-drawer-layout position="start" width="220px" min-width="64px">
+  <nav><a href="#">Overview</a><a href="#">Runs</a><a href="#">Settings</a></nav>
+</aside>`,
+
+  'x-move': `<button x-move distance="120px" duration="0.6s">Move me</button>`,
+
+  'x-release': `<div x-release version="3.0.48" date="2026-08-20">
+  143 behavior docs, curated showcase examples, dropdown fixes.
+</div>`,
+
+  'x-resizable': `<div x-resizable handles="se">
+  Grab the corner and resize this panel.
+</div>`,
+
+  'x-scrollalong': `<aside x-scrollalong offset="16">
+  Keeps pace with the page as you scroll.
+</aside>`,
+
+  'x-stagelight': `<div x-stagelight variant="spotlight" color="#f59e0b" intensity="0.5" size="360px">
+  The spotlight follows the pointer across this panel.
+</div>`,
+
+  'x-sticky': `<div x-sticky offset="0" stuck-class="is-stuck">
+  Sticks to the top of its scroll container once you pass it.
+</div>`,
+
+  'x-tags': `<input x-tags value="light-dom,no-build,playwright" placeholder="Add a tag…">`,
+};
+
+// ── merge ─────────────────────────────────────────────────────────────────────
+const raw = JSON.parse(fs.readFileSync(CATALOGUE, 'utf8'));
+const existing = raw.examples || {};
+
+const added = [];
+const skipped = [];
+for (const [token, source] of Object.entries(EXAMPLES)) {
+  if (existing[token]) { skipped.push(token); continue; }
+  added.push(token);
+  if (!CHECK) existing[token] = { source, alternates: [] };
+}
+
+if (CHECK) {
+  console.log(`[seed-examples] would add ${added.length}, leaving ${skipped.length} curated entries alone`);
+  process.exit(0);
+}
+
+raw.examples = existing;
+raw.count = Object.keys(existing).length;
+fs.writeFileSync(CATALOGUE, JSON.stringify(raw, null, 2) + '\n', 'utf8');
+console.log(`[seed-examples] added ${added.length} example(s); ${skipped.length} already curated and left alone. Catalogue now ${raw.count}.`);

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -3,7 +3,7 @@
  * Regenerated on every commit via .husky/pre-commit.
  */
 export const VERSION = {
-  "version": "3.0.48",
-  "commit": "644df89",
-  "builtAt": "2026-08-20T22:43:45.271Z"
+  "version": "3.0.49",
+  "commit": "794116a",
+  "builtAt": "2026-08-20T23:03:09.674Z"
 };

--- a/tests/behaviors/behaviors-browse-navigation.spec.ts
+++ b/tests/behaviors/behaviors-browse-navigation.spec.ts
@@ -298,3 +298,61 @@ test.describe('#711 — the example is centred in the stage', () => {
     });
   }
 });
+
+test.describe('#717 — the selection is the first row anywhere in the list', () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  for (const filter of ['button', 'x-'] as const) {
+    test(`"${filter}": Down, End and Up all leave the selection at the top`, async ({ page }) => {
+      test.setTimeout(120_000);
+      await loadBrowse(page, filter);
+
+      const worst = await page.evaluate(async () => {
+        const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+        const list = document.getElementById('behaviors-search-results')!;
+        const rows = [...list.querySelectorAll('.behaviors-search-results__row')] as HTMLElement[];
+        const press = (key: string) =>
+          list.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+        const offset = () => {
+          const cur = list.querySelector('[aria-current="true"]') as HTMLElement;
+          return Math.round((cur.offsetTop - list.offsetTop) - list.scrollTop);
+        };
+
+        rows[0].focus();
+        let down = 0;
+        for (let i = 0; i < 6; i++) { press('ArrowDown'); await sleep(160); down = Math.max(down, Math.abs(offset())); }
+
+        // End is the case that used to fail worst: scrollTop clamps at
+        // scrollHeight - clientHeight, so the last screenful could never reach
+        // the top -- measured 1134px down before the trailing room was added.
+        press('End');
+        await sleep(400);
+        const end = Math.abs(offset());
+
+        let up = 0;
+        for (let i = 0; i < 6; i++) { press('ArrowUp'); await sleep(160); up = Math.max(up, Math.abs(offset())); }
+
+        return { rows: rows.length, down, end, up };
+      });
+
+      expect(worst.rows, 'expected rows to walk').toBeGreaterThan(5);
+      expect(worst.down, 'ArrowDown must pin the selection to the top').toBeLessThanOrEqual(2);
+      expect(worst.end, 'End must put the LAST row at the top').toBeLessThanOrEqual(2);
+      expect(worst.up, 'ArrowUp must pin the selection to the top').toBeLessThanOrEqual(2);
+    });
+  }
+
+  test('a list too short to scroll gains no trailing padding', async ({ page }) => {
+    await loadBrowse(page, 'x-globe');   // a single behavior
+    await page.waitForTimeout(500);
+    const state = await page.evaluate(() => {
+      const list = document.getElementById('behaviors-search-results')!;
+      return {
+        rows: list.querySelectorAll('.behaviors-search-results__row').length,
+        padding: list.style.paddingBottom,
+      };
+    });
+    expect(state.rows, 'expected a short list').toBeLessThan(5);
+    expect(state.padding, 'nothing to scroll — no padding needed').toBe('');
+  });
+});

--- a/tests/compliance/behavior-example-quality.spec.ts
+++ b/tests/compliance/behavior-example-quality.spec.ts
@@ -1,0 +1,61 @@
+/**
+ * #715 — no showcase example may be a placeholder.
+ *
+ * 83 of 143 behaviors rendered `<article variant="flat">Example article
+ * content</article>` — the generated fallback that fires when a token has no
+ * entry in data/behavior-examples.json. The schema supplies the tag and the
+ * attribute; the BODY is filler, and for a container-shaped behavior filler is
+ * exactly why there is nothing to look at (the x-dropdown empty menu, #701).
+ *
+ * Reads the code panel the reader reads, so it cannot pass on a catalogue entry
+ * that fails to render.
+ */
+import { test, expect } from '@playwright/test';
+
+const PLACEHOLDER = /Example [\w-]+ content/;
+
+test('no behavior example is a placeholder', async ({ page }) => {
+  test.setTimeout(300_000);
+
+  await page.goto('/?page=behaviors');
+  await page.waitForSelector('#behaviors-search', { timeout: 30000 });
+  await page.fill('#behaviors-search', 'x-');
+  await page.waitForFunction(
+    () => document.querySelectorAll('.behaviors-search-results__row').length > 50,
+    { timeout: 30000 },
+  );
+
+  const targets = await page.evaluate(() => {
+    const seen = new Map();
+    [...document.querySelectorAll('.behaviors-search-results__row')].forEach((r, i) => {
+      const t = r.getAttribute('data-browse-token') || '';
+      if (!seen.has(t)) seen.set(t, i);
+    });
+    return [...seen.entries()].map(([token, index]) => ({ token, index }));
+  });
+
+  const stubs = [];
+  for (let start = 0; start < targets.length; start += 20) {
+    const results = await page.evaluate(async (items) => {
+      const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+      const rows = [...document.querySelectorAll('.behaviors-search-results__row')];
+      const out = [];
+      for (const { token, index } of items) {
+        rows[index].click();
+        await sleep(160);
+        const code = document.getElementById('behaviors-live-code');
+        out.push({ token, code: (code?.textContent || '').replace(/^Copy[\d]*/, '').trim() });
+      }
+      return out;
+    }, targets.slice(start, start + 20));
+    for (const r of results) if (PLACEHOLDER.test(r.code)) stubs.push(r.token);
+  }
+
+  console.log(`[#715] examples: ${targets.length - stubs.length}/${targets.length} real, ${stubs.length} placeholder`);
+
+  expect(
+    stubs,
+    `${stubs.length} of ${targets.length} behaviors render a placeholder example — give each one an entry in data/behavior-examples.json:\n  ` +
+    stubs.join('\n'),
+  ).toEqual([]);
+});


### PR DESCRIPTION
## #715 — 83 placeholder examples, and a correction

I told John earlier that the stub examples and the thin docs shared one missing-schema cause. **That was wrong.** `x-card` *has* a schema — 9 properties — and still rendered:

```html
<article variant="flat">
  Example article content
</article>
```

The schema supplies the tag and the attribute; the **body** is the generated fallback, which fires whenever a token has no entry in `data/behavior-examples.json`. Schemas alone would have left all 83 saying "Example … content".

**94 curated examples**, written by hand against each behavior's own schema properties in kebab-case, with real content:

- `x-cardpricing` — a real plan, price, period and feature list
- `x-cardproduct` — price and strikethrough original
- `x-cardtestimonial` — a quote, an author, a rating
- `x-accordion` — three real questions with real answers
- `x-form` — real fields with validation attributes
- `x-tabs` — three sections with actual content

The 17 already-curated entries were left untouched.

**The gate** (`behavior-example-quality.spec.ts`) walks all 143 and reads the code panel the reader reads — it cannot pass on a catalogue entry that fails to render.

| | before | after |
|---|---|---|
| real examples | 60 / 143 | **143 / 143** |

## #717 — "the current selection must be the first one"

#687 pinned the selection to the top. It held until the list ran out of scroll: `selectRow()` sets `scrollTop = rowTop`, the browser clamps at `scrollHeight - clientHeight`, and the last screenful has nothing below it to scroll into view.

Measured on the 49-row `button` list — **row 48 sat 1134px down**, drifting further the closer to the end.

Trailing room equal to `viewport - lastRow` puts every row within reach of the top, only while the list actually scrolls. Then **two corrections I only found by measuring after each attempt**:

1. The arithmetic alone left the last row **4px** short and row 47 **18px** short — rows differ in height and the border/gaps aren't in that subtraction. The shortfall is now measured and topped up rather than trusted.
2. ArrowUp still drifted **18px** (49 rows) and **99px** (585) — every press renders a different example, which resizes the panel, which resizes the list, landing *after* `selectRow()` set `scrollTop`. The aligned row is re-pinned once the layout settles.

| | Down | End | Up |
|---|---|---|---|
| 49 rows | **0px** | **0px** | **0px** |
| 585 rows | **0px** | **0px** | **0px** |

## Test plan

- [x] `behavior-example-quality` — 143/143 real, 0 placeholder
- [x] `behaviors-browse-navigation` — **16/16** (13 + 3 new)
- [x] #717 covered on both a 49-row and the full 585-row list
- [x] A list too short to scroll gains no padding

Closes #715
Closes #717