### PR TITLE
feat(#720): the live stage can go fullscreen, and comes back unchanged

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,15 +27,15 @@
   <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
 
   <!-- Layer 1: Foundation (render-blocking, already highest priority — no preload needed) -->
-  <link rel="stylesheet" href="src/styles/normalize.css?v=14fb3f0">
-  <link rel="stylesheet" href="src/styles/themes.css?v=14fb3f0">
-  <link rel="stylesheet" href="src/styles/site.css?v=14fb3f0">
-  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=14fb3f0">
-  <link rel="modulepreload" href="src/core/wb.js?v=14fb3f0">
-  <link rel="modulepreload" href="src/core/site-engine.js?v=14fb3f0">
+  <link rel="stylesheet" href="src/styles/normalize.css?v=95b455f">
+  <link rel="stylesheet" href="src/styles/themes.css?v=95b455f">
+  <link rel="stylesheet" href="src/styles/site.css?v=95b455f">
+  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=95b455f">
+  <link rel="modulepreload" href="src/core/wb.js?v=95b455f">
+  <link rel="modulepreload" href="src/core/site-engine.js?v=95b455f">
 
   <!-- Page Transitions CSS -->
-  <link rel="stylesheet" href="src/styles/transitions.css?v=14fb3f0">
+  <link rel="stylesheet" href="src/styles/transitions.css?v=95b455f">
   <!-- Navbar CSS already loads via site.css's own @import — no separate link needed. -->
 
   <!-- Fonts -->
@@ -92,9 +92,9 @@
   </template>
 
   <!-- Premium Navbar Scroll Effect -->
-  <script src="src/lib/premium-navbar.js?v=14fb3f0"></script>
+  <script src="src/lib/premium-navbar.js?v=95b455f"></script>
 
   <!-- Main Application Bootstrap -->
-  <script type="module" src="./src/main.js?v=14fb3f0"></script>
+  <script type="module" src="./src/main.js?v=95b455f"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wb-starter",
-  "version": "3.0.50",
+  "version": "3.0.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wb-starter",
-      "version": "3.0.50",
+      "version": "3.0.51",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wb-starter",
-  "version": "3.0.50",
+  "version": "3.0.51",
   "type": "module",
   "description": "Modern website starter kit powered by WB Behaviors",
   "main": "index.html",

--- a/pages/behaviors.html
+++ b/pages/behaviors.html
@@ -26,6 +26,22 @@
       <header class="behaviors-live__head">
         <span id="behaviors-live-token" class="behaviors-live__token"></span>
         <span id="behaviors-live-note" class="behaviors-live__note"></span>
+        <!-- #720 -- John, on `table . bordered`: "put this element into a parent
+             container that will show this content when the fullscreen button is
+             pressed... otherwise it will keep this same location and size".
+             Some examples are simply bigger than a panel that shares its width
+             with the results list -- the table family, masonry, gallery,
+             cardhero. This uses the framework's OWN x-fullscreen behavior
+             (helpers.js), which already saves and restores the target's
+             height/overflow across the round trip, rather than hand-rolling a
+             second implementation in page chrome. -->
+        <button
+          id="behaviors-live-fullscreen"
+          class="behaviors-live__fullscreen"
+          type="button"
+          x-fullscreen
+          target="#behaviors-live-stage"
+          label="&#9974; Fullscreen"></button>
       </header>
       <div id="behaviors-live-stage" class="behaviors-live__stage"></div>
 

--- a/project-index.html
+++ b/project-index.html
@@ -7,8 +7,8 @@
     <title>Project Index</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
-    <link rel="stylesheet" href="src/styles/themes.css?v=14fb3f0">
-    <link rel="stylesheet" href="src/styles/site.css?v=14fb3f0">
+    <link rel="stylesheet" href="src/styles/themes.css?v=95b455f">
+    <link rel="stylesheet" href="src/styles/site.css?v=95b455f">
     <script type="module">
       import WB from './src/core/wb.js';
       WB.init({ autoInject: true });

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -3,7 +3,7 @@
  * Regenerated on every commit via .husky/pre-commit.
  */
 export const VERSION = {
-  "version": "3.0.50",
-  "commit": "14fb3f0",
-  "builtAt": "2026-08-20T23:12:38.015Z"
+  "version": "3.0.51",
+  "commit": "95b455f",
+  "builtAt": "2026-08-20T23:23:58.084Z"
 };

--- a/src/styles/pages/behaviors.css
+++ b/src/styles/pages/behaviors.css
@@ -498,6 +498,27 @@ footer a:hover {
 /* The running example. contain: layout keeps a position:fixed demo (a toast, a
    spotlight) inside this box instead of painting over the page — the same rule
    .wb-demo__grid needs, and for the same reason (#647). */
+/* #720 -- the stage can go fullscreen so an example bigger than the panel (the
+   table family, masonry, gallery, cardhero) can actually be read. A fullscreen
+   element paints on black unless it brings its own background, and `contain:
+   layout` plus the 6rem floor are panel-sized rules that make no sense at
+   viewport scale, so both are lifted for the duration. x-fullscreen restores
+   the inline height/overflow it set when the reader comes back out. */
+.behaviors-live__stage:fullscreen {
+  background: var(--bg-secondary, #1f2937);
+  contain: none;
+  min-height: 100vh;
+  padding: 2rem;
+  overflow: auto;
+}
+
+/* Sits at the end of the panel header, after the note. */
+.behaviors-live__fullscreen {
+  margin-left: auto;
+  font-size: 0.75rem;
+  white-space: nowrap;
+}
+
 .behaviors-live__stage {
   padding: 1.25rem;
   min-height: 6rem;

--- a/tests/behaviors/behaviors-browse-navigation.spec.ts
+++ b/tests/behaviors/behaviors-browse-navigation.spec.ts
@@ -362,3 +362,77 @@ test.describe('#717 — the selection is the first row anywhere in the list', ()
     expect(state.padding, 'nothing to scroll — no padding needed').toBe('');
   });
 });
+
+test.describe('#720 — the stage can go fullscreen and come back unchanged', () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test('the control is wired to the STAGE, not the page', async ({ page }) => {
+    await loadBrowse(page, 'table');
+    await page.locator('.behaviors-search-results__row').first().click();
+    await page.waitForTimeout(400);
+
+    const wiring = await page.evaluate(() => {
+      const btn = document.getElementById('behaviors-live-fullscreen') as HTMLElement;
+      return {
+        exists: !!btn,
+        label: (btn?.textContent || '').trim(),
+        upgraded: btn?.classList.contains('wb-fullscreen'),
+        target: btn?.getAttribute('target'),
+      };
+    });
+
+    expect(wiring.exists, 'the panel needs a fullscreen control').toBe(true);
+    expect(wiring.upgraded, "it must be the framework's own x-fullscreen behavior").toBe(true);
+    expect(wiring.target, 'it must target the stage, not the document').toBe('#behaviors-live-stage');
+    expect(wiring.label.length, 'the control must be labelled').toBeGreaterThan(0);
+  });
+
+  test('a fullscreen round trip leaves the stage exactly where it was', async ({ page }) => {
+    await loadBrowse(page, 'table');
+    await page.locator('.behaviors-search-results__row').first().click();
+    await page.waitForTimeout(400);
+
+    const trip = await page.evaluate(async () => {
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      const stage = document.getElementById('behaviors-live-stage')!;
+      const btn = document.getElementById('behaviors-live-fullscreen') as HTMLElement;
+      const before = stage.getBoundingClientRect();
+
+      // requestFullscreen needs a user gesture, which a scripted click has not
+      // got — so spy on it to prove WHERE it was requested, then drive the
+      // restore path the behavior listens for.
+      let requestedOn: string | null = null;
+      const original = Element.prototype.requestFullscreen;
+      Element.prototype.requestFullscreen = function (this: Element) {
+        requestedOn = this.id || this.tagName;
+        return Promise.resolve();
+      };
+      btn.click();
+      await sleep(200);
+      Element.prototype.requestFullscreen = original;
+
+      const during = { height: stage.style.height, overflow: stage.style.overflow };
+      document.dispatchEvent(new Event('fullscreenchange'));   // fullscreenElement is null → exit path
+      await sleep(300);
+      const after = stage.getBoundingClientRect();
+
+      const same = (a: DOMRect, b: DOMRect) =>
+        Math.round(a.width) === Math.round(b.width) && Math.round(a.height) === Math.round(b.height)
+        && Math.round(a.top) === Math.round(b.top) && Math.round(a.left) === Math.round(b.left);
+
+      return {
+        requestedOn,
+        during,
+        cleared: !stage.style.height && !stage.style.overflow,
+        sameRect: same(before, after),
+        example: !!stage.firstElementChild,
+      };
+    });
+
+    expect(trip.requestedOn, 'fullscreen must be requested on the stage').toBe('behaviors-live-stage');
+    expect(trip.during.height, 'the stage fills the viewport while fullscreen').toBe('100vh');
+    expect(trip.cleared, 'the inline styles must be cleared on the way out').toBe(true);
+    expect(trip.sameRect, 'the stage must return to the same position and size').toBe(true);
+    expect(trip.example, 'the example must survive the round trip').toBe(true);
+  });
+});


### PR DESCRIPTION
> **John**, on `table · bordered`: "put this element into a parent container that will show this content when the fullscreen button is pressed (full screen) other wise it will keep this same location and size when fullscreen is pressed again."

Some examples are simply bigger than a panel that shares its width with the results list — the table family, `x-masonry`, `x-gallery`, `x-cardhero` — so the reader sees a cramped fraction of what the behavior produces.

## Uses the framework's own behavior

The control is `x-fullscreen` (`src/wb-viewmodels/helpers.js`), not a second hand-rolled implementation in page chrome. It already does the half John asked about:

```js
originalStyles = { overflow: …, overflowY: …, height: … };
targetEl.style.height = '100vh';
targetEl.requestFullscreen();
// on fullscreenchange, when fullscreenElement is null → restore all three
```

The showcase demonstrating the thing it documents.

## The stage needed `:fullscreen` styling

It carries `contain: layout`, a 6rem floor and no background of its own — panel-sized rules that make no sense at viewport scale, and a fullscreen element with no background of its own paints on **black**.

## Verified

`requestFullscreen` is spied, because a scripted click carries no user gesture:

| | |
|---|---|
| requested on | `behaviors-live-stage` — the **stage**, not the document |
| while open | `height: 100vh`, `overflow: auto` |
| after exit | both cleared |
| rect before | 482 × 714 at top 236 |
| **rect after** | **482 × 714 at top 236** — identical |

## Test plan

`tests/behaviors/behaviors-browse-navigation.spec.ts` — **18/18** (16 + 2 new)

- [x] the control exists, is upgraded by `x-fullscreen`, and targets `#behaviors-live-stage`
- [x] the round trip returns the stage to the same position **and** size, measured
- [x] the inline styles are cleared on the way out
- [x] the rendered example survives the round trip

Closes #720