### PR TITLE
fix(#722): fullscreen expands the example, not the panel-sized stage around it

### DIFF
--- a/pages/behaviors.html
+++ b/pages/behaviors.html
@@ -40,10 +40,17 @@
           class="behaviors-live__fullscreen"
           type="button"
           x-fullscreen
-          target="#behaviors-live-stage"
+          target="#behaviors-live-example"
           label="&#9974; Fullscreen"></button>
       </header>
-      <div id="behaviors-live-stage" class="behaviors-live__stage"></div>
+      <!-- #722 -- John: "When clicking fullscreen all of these elements go
+           fullscreen." The STAGE is the panel-sized surface the example is
+           centred in (#710/#711), so expanding it expanded the empty space too.
+           This wrapper is the parent container the original ask asked for: it
+           hugs the rendered example, and it is what goes fullscreen. -->
+      <div id="behaviors-live-stage" class="behaviors-live__stage">
+        <div id="behaviors-live-example" class="behaviors-live__example"></div>
+      </div>
 
       <!-- #666 — John: "switch the html to be right under the rendered thing,
            then put the event hook up last, but show the events right under the
@@ -447,6 +454,7 @@
     const liveToken = document.getElementById('behaviors-live-token');
     const liveNote = document.getElementById('behaviors-live-note');
     const liveStage = document.getElementById('behaviors-live-stage');
+    const liveExample = document.getElementById('behaviors-live-example');
     const liveCode = document.getElementById('behaviors-live-code');
     const liveDoc = document.getElementById('behaviors-live-doc');
     let liveDocBody = document.getElementById('behaviors-live-doc-body');
@@ -1005,7 +1013,7 @@
         // second pass the new wrapper is firstElementChild while the original
         // already carries `root`. Handing it out twice would put a duplicate
         // id in the document and break the very selector the snippet teaches.
-        if (el === liveStage.firstElementChild && !document.getElementById(root)) {
+        if (el === liveExample.firstElementChild && !document.getElementById(root)) {
           el.id = root;
           return;
         }
@@ -1017,7 +1025,7 @@
         while (document.getElementById(candidate)) candidate = `${name}-${++n}`;
         el.id = candidate;
       });
-      return liveStage.firstElementChild ? liveStage.firstElementChild.id : null;
+      return liveExample.firstElementChild ? liveExample.firstElementChild.id : null;
     }
 
     // Examples that need behaviour beyond what a behavior provides are wired
@@ -1236,7 +1244,7 @@
       const from = describeElement(target);
       // An event that started on a descendant is a different story from one on
       // the example root, and that difference is exactly what was missing.
-      const root = liveStage.firstElementChild;
+      const root = liveExample.firstElementChild;
       const origin = target && root && target !== root && root.contains(target)
         ? ` <span class="behaviors-live__events-from">from ${describeElement(root)}</span>` : '';
       const li = document.createElement('li');
@@ -1403,13 +1411,13 @@
         const generated = generatedExample(token, variant, label, prop, isBool);
         liveNote.textContent = 'generated example — no demo on this page';
         liveCode.innerHTML = '';
-        liveStage.innerHTML = generated;
+        liveExample.innerHTML = generated;
         const genRootId = assignExampleIds(token, optionText);
-        resetEvents(liveStage.firstElementChild && liveStage.firstElementChild.tagName.toLowerCase(), token, genRootId);
+        resetEvents(liveExample.firstElementChild && liveExample.firstElementChild.tagName.toLowerCase(), token, genRootId);
         await renderSource(generated);
         assignExampleIds(token, optionText); // #675: catch behavior-injected children
         const genDescribed = optionDescription(token, prop);
-        const genSummary = genDescribed || summarise(liveStage.firstElementChild);
+        const genSummary = genDescribed || summarise(liveExample.firstElementChild);
         liveNote.textContent = genSummary
           ? `generated — ${genSummary}`
           : 'generated example — no demo on this page';
@@ -1419,9 +1427,9 @@
       liveNote.textContent = optionDescription(token, prop) || 'running live';
       // #703: drop the previous example's grown height before measuring this one.
       liveStage.style.minHeight = '';
-      liveStage.innerHTML = src;
+      liveExample.innerHTML = src;
       const rootId = assignExampleIds(token, optionText);
-      resetEvents(liveStage.firstElementChild && liveStage.firstElementChild.tagName.toLowerCase(), token, rootId);
+      resetEvents(liveExample.firstElementChild && liveExample.firstElementChild.tagName.toLowerCase(), token, rootId);
       await renderSource(src);
       assignExampleIds(token, optionText); // #675: catch behavior-injected children
       // After the upgrade, so the summary describes the UPGRADED element rather
@@ -1432,7 +1440,7 @@
       // and it is accurate for options with no visible surface change, where
       // summarise() can only ever report the host's background.
       const described = optionDescription(token, prop);
-      const summary = described || summarise(liveStage.firstElementChild);
+      const summary = described || summarise(liveExample.firstElementChild);
       if (summary) liveNote.textContent = summary;
       // #703: an example can render something taller than the stage's 6rem
       // floor even before anything is opened.

--- a/src/styles/pages/behaviors.css
+++ b/src/styles/pages/behaviors.css
@@ -504,6 +504,23 @@ footer a:hover {
    layout` plus the 6rem floor are panel-sized rules that make no sense at
    viewport scale, so both are lifted for the duration. x-fullscreen restores
    the inline height/overflow it set when the reader comes back out. */
+/* #722 -- the wrapper the example renders into, and the thing that goes
+   fullscreen. Full width normally so a block example (<article>, <table>) fills
+   the stage exactly as it did when it rendered straight into it; in fullscreen
+   it brings its own background and centres, because a fullscreen element with
+   none paints on black. */
+.behaviors-live__example {
+  width: 100%;
+}
+
+.behaviors-live__example:fullscreen {
+  background: var(--bg-secondary, #1f2937);
+  padding: 2rem;
+  overflow: auto;
+  display: grid;
+  align-content: center;
+}
+
 .behaviors-live__stage:fullscreen {
   background: var(--bg-secondary, #1f2937);
   contain: none;

--- a/tests/behaviors/behaviors-browse-navigation.spec.ts
+++ b/tests/behaviors/behaviors-browse-navigation.spec.ts
@@ -244,7 +244,12 @@ test.describe('#720 — the stage can go fullscreen and come back unchanged', ()
 
     expect(wiring.exists, 'the panel needs a fullscreen control').toBe(true);
     expect(wiring.upgraded, "it must be the framework's own x-fullscreen behavior").toBe(true);
-    expect(wiring.target, 'it must target the stage, not the document').toBe('#behaviors-live-stage');
+    // #722 -- John: "When clicking fullscreen all of these elements go
+    // fullscreen." The stage is the panel-sized surface the example is centred
+    // in, so expanding it expanded the empty space too. The target is the
+    // wrapper that hugs the example.
+    expect(wiring.target, 'it must target the example wrapper, not the stage or the document')
+      .toBe('#behaviors-live-example');
     expect(wiring.label.length, 'the control must be labelled').toBeGreaterThan(0);
   });
 
@@ -256,8 +261,10 @@ test.describe('#720 — the stage can go fullscreen and come back unchanged', ()
     const trip = await page.evaluate(async () => {
       const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
       const stage = document.getElementById('behaviors-live-stage')!;
+      const wrapper = document.getElementById('behaviors-live-example')!;
       const btn = document.getElementById('behaviors-live-fullscreen') as HTMLElement;
-      const before = stage.getBoundingClientRect();
+      const before = wrapper.getBoundingClientRect();
+      const stageBefore = stage.getBoundingClientRect();
 
       // requestFullscreen needs a user gesture, which a scripted click has not
       // got — so spy on it to prove WHERE it was requested, then drive the
@@ -272,10 +279,11 @@ test.describe('#720 — the stage can go fullscreen and come back unchanged', ()
       await sleep(200);
       Element.prototype.requestFullscreen = original;
 
-      const during = { height: stage.style.height, overflow: stage.style.overflow };
+      const during = { height: wrapper.style.height, overflow: wrapper.style.overflow };
       document.dispatchEvent(new Event('fullscreenchange'));   // fullscreenElement is null → exit path
       await sleep(300);
-      const after = stage.getBoundingClientRect();
+      const after = wrapper.getBoundingClientRect();
+      const stageAfter = stage.getBoundingClientRect();
 
       const same = (a: DOMRect, b: DOMRect) =>
         Math.round(a.width) === Math.round(b.width) && Math.round(a.height) === Math.round(b.height)
@@ -284,16 +292,18 @@ test.describe('#720 — the stage can go fullscreen and come back unchanged', ()
       return {
         requestedOn,
         during,
-        cleared: !stage.style.height && !stage.style.overflow,
+        cleared: !wrapper.style.height && !wrapper.style.overflow,
         sameRect: same(before, after),
-        example: !!stage.firstElementChild,
+        stageSameRect: same(stageBefore, stageAfter),
+        example: !!wrapper.firstElementChild,
       };
     });
 
-    expect(trip.requestedOn, 'fullscreen must be requested on the stage').toBe('behaviors-live-stage');
-    expect(trip.during.height, 'the stage fills the viewport while fullscreen').toBe('100vh');
+    expect(trip.requestedOn, 'fullscreen must be requested on the example wrapper').toBe('behaviors-live-example');
+    expect(trip.during.height, 'the example fills the viewport while fullscreen').toBe('100vh');
     expect(trip.cleared, 'the inline styles must be cleared on the way out').toBe(true);
-    expect(trip.sameRect, 'the stage must return to the same position and size').toBe(true);
+    expect(trip.sameRect, 'the example must return to the same position and size').toBe(true);
+    expect(trip.stageSameRect, 'and the stage around it must not move either').toBe(true);
     expect(trip.example, 'the example must survive the round trip').toBe(true);
   });
 });


### PR DESCRIPTION
> **John**: "When clicking fullscreen all of these elements go fullscreen."

#720 pointed `x-fullscreen` at `#behaviors-live-stage`. Since #710 the stage is as tall as the whole panel, and since #711 it centres its content — so it is mostly **empty space** around the example. Expanding it expanded the empty box too.

The original ask was for a parent container around the **element**:

> "put this element into a parent container that will show this content when the fullscreen button is pressed"

The stage is not that container — it is the panel-sized surface the example is centred *in*. `#behaviors-live-example` is: it hugs the rendered example, `showLive()` renders into it, and it is what goes fullscreen.

Everything else still measures the stage: the event logger, the overlay fit (#703) and the centring (#711).

## Verified at 1280×900

| | |
|---|---|
| requested on | `behaviors-live-example` |
| while open | `height: 100vh`, `overflow: auto` |
| after exit | cleared — wrapper **698×180** and the stage around it both identical to before |
| example | still rendered |

## One thing worth recording

While the Browser pane was hidden, the viewport measured **0px wide**, and every geometry read in it was garbage — the article example "measured" 2558px tall because its text was wrapping one character per line. I nearly filed that as a layout bug. Restoring a real viewport showed a 698×180 card. Geometry read from a zero-width viewport means nothing.

## Test plan

- [x] `behaviors-browse-navigation` fullscreen tests updated to the wrapper contract and passing
- [x] Round trip asserts **both** the wrapper and the stage return to the same position and size

Closes #722