### PR TITLE
fix(#728): arrow keys move the selection; the list stays put

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,15 +27,15 @@
   <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
 
   <!-- Layer 1: Foundation (render-blocking, already highest priority — no preload needed) -->
-  <link rel="stylesheet" href="src/styles/normalize.css?v=95b455f">
-  <link rel="stylesheet" href="src/styles/themes.css?v=95b455f">
-  <link rel="stylesheet" href="src/styles/site.css?v=95b455f">
-  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=95b455f">
-  <link rel="modulepreload" href="src/core/wb.js?v=95b455f">
-  <link rel="modulepreload" href="src/core/site-engine.js?v=95b455f">
+  <link rel="stylesheet" href="src/styles/normalize.css?v=85a5df7">
+  <link rel="stylesheet" href="src/styles/themes.css?v=85a5df7">
+  <link rel="stylesheet" href="src/styles/site.css?v=85a5df7">
+  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=85a5df7">
+  <link rel="modulepreload" href="src/core/wb.js?v=85a5df7">
+  <link rel="modulepreload" href="src/core/site-engine.js?v=85a5df7">
 
   <!-- Page Transitions CSS -->
-  <link rel="stylesheet" href="src/styles/transitions.css?v=95b455f">
+  <link rel="stylesheet" href="src/styles/transitions.css?v=85a5df7">
   <!-- Navbar CSS already loads via site.css's own @import — no separate link needed. -->
 
   <!-- Fonts -->
@@ -92,9 +92,9 @@
   </template>
 
   <!-- Premium Navbar Scroll Effect -->
-  <script src="src/lib/premium-navbar.js?v=95b455f"></script>
+  <script src="src/lib/premium-navbar.js?v=85a5df7"></script>
 
   <!-- Main Application Bootstrap -->
-  <script type="module" src="./src/main.js?v=95b455f"></script>
+  <script type="module" src="./src/main.js?v=85a5df7"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wb-starter",
-  "version": "3.0.51",
+  "version": "3.0.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wb-starter",
-      "version": "3.0.51",
+      "version": "3.0.52",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wb-starter",
-  "version": "3.0.51",
+  "version": "3.0.52",
   "type": "module",
   "description": "Modern website starter kit powered by WB Behaviors",
   "main": "index.html",

--- a/pages/behaviors.html
+++ b/pages/behaviors.html
@@ -381,9 +381,6 @@
       });
       if (!q) totalRowCount = rendered;
       resultsEl.appendChild(frag);
-      // #717: a new filter is a new set of rows -- the trailing room has to be
-      // recomputed for THIS list, not the one it replaced.
-      if (typeof syncTailRoom === 'function') syncTailRoom();
     }
 
     // Which hit does the reader actually mean? Typing "button" matched
@@ -516,7 +513,7 @@
         // Only write on a real change -- an unconditional write re-triggers the
         // observer every frame for no reason.
         if (resultsEl.style.maxHeight !== next) resultsEl.style.maxHeight = next;
-        syncTailRoom();
+        keepSelectionVisible();
       });
     }
     // #717 -- John: "When using the down or up button the current selection must
@@ -527,47 +524,28 @@
     // Trailing space equal to (viewport - last row) puts every row within reach
     // of the top. Only while the list actually scrolls -- a short list gains
     // nothing from it and would just grow a scrollbar.
-    // The row the keyboard last pinned to the top. Padding changes move the
-    // scroll range under it, so the alignment has to be re-applied afterwards.
-    let alignedRow = null;
+    // #728 -- every arrow press renders a different example, which resizes the
+    // panel, which resizes the list (#710) -- AFTER selectRow() has already
+    // scrolled. Measured: End selected the last row and then the resize left it
+    // out of view. This re-asserts VISIBILITY only, by the same minimum-scroll
+    // rule; it does not pin the row anywhere, which is what John asked to be
+    // rid of.
+    // Keyboard only. #664's contract is that a CLICK leaves the list exactly
+    // where the reader put it -- re-asserting visibility after a click broke
+    // that, because the panel resize that follows every render would drag the
+    // list to a row the reader had deliberately scrolled away from.
+    let selectedByKeyboard = false;
 
-    function realignAligned() {
-      if (!alignedRow || !alignedRow.isConnected) return;
-      const top = alignedRow.offsetTop - resultsEl.offsetTop;
-      if (Math.round(resultsEl.scrollTop) !== Math.round(top)) resultsEl.scrollTop = top;
-    }
-
-    function syncTailRoom() {
-      const rows = resultsEl.querySelectorAll('.behaviors-search-results__row');
-      const last = rows[rows.length - 1];
-      if (!last) { resultsEl.style.paddingBottom = ''; return; }
-      const current = parseFloat(resultsEl.style.paddingBottom) || 0;
-      const contentHeight = resultsEl.scrollHeight - current;
-      if (contentHeight <= resultsEl.clientHeight + 1) {
-        if (current) resultsEl.style.paddingBottom = '';
-        return;
+    function keepSelectionVisible() {
+      if (!selectedByKeyboard) return;
+      const cur = resultsEl.querySelector('[aria-current="true"]');
+      if (!cur) return;
+      const top = cur.offsetTop - resultsEl.offsetTop;
+      const bottom = top + cur.offsetHeight;
+      if (top < resultsEl.scrollTop) resultsEl.scrollTop = top;
+      else if (bottom > resultsEl.scrollTop + resultsEl.clientHeight) {
+        resultsEl.scrollTop = bottom - resultsEl.clientHeight;
       }
-      const room = Math.max(0, Math.round(resultsEl.clientHeight - last.offsetHeight));
-      const next = room + 'px';
-      if (resultsEl.style.paddingBottom !== next) resultsEl.style.paddingBottom = next;
-
-      // Then CHECK it, rather than trusting the arithmetic: rows differ in
-      // height (a long token wraps), and the list's own border and row gaps are
-      // not in that subtraction. Measured with the estimate alone, the last row
-      // still landed 4px short and row 47 18px short. Top up by exactly the
-      // shortfall -- once the last row can reach the top, so can every row
-      // above it, since each one needs less scroll than the last.
-      const lastTop = last.offsetTop - resultsEl.offsetTop;
-      const maxScroll = resultsEl.scrollHeight - resultsEl.clientHeight;
-      if (maxScroll < lastTop) {
-        resultsEl.style.paddingBottom = (room + Math.ceil(lastTop - maxScroll)) + 'px';
-      }
-
-      // #717: every arrow press renders a different example, which resizes the
-      // panel, which resizes the list, which lands here -- AFTER selectRow()
-      // already set scrollTop. Measured: ArrowUp drifted 18px on a 49-row list
-      // and 99px on the full 585. Re-pin the row the keyboard aligned.
-      realignAligned();
     }
 
     // The panel's height drives the list's; the list never drives the panel's,
@@ -1473,7 +1451,7 @@
       return [...resultsEl.querySelectorAll('.behaviors-search-results__row')];
     }
 
-    function selectRow(row, { focus = true, reveal = false, align = false } = {}) {
+    function selectRow(row, { focus = true, reveal = false } = {}) {
       if (!row) return;
       rowsInOrder().forEach((r) => r.removeAttribute('aria-current'));
       row.setAttribute('aria-current', 'true');
@@ -1482,20 +1460,15 @@
       // measured moving the page from 5541 to 341 while arrowing. The panel
       // exists so the page does not move (John: "don't scroll down"), so the
       // list's own scrollTop is adjusted directly and nothing else is touched.
+      // #728 -- John, having used the align-to-top version: "set it to normal
+      // action on key up and or down. I don't like the always at top stuff."
+      // So: move the selection, and scroll ONLY when the row would otherwise be
+      // out of view, by the minimum needed. A row already on screen leaves the
+      // list where it is. This replaces #687/#717.
       const listTop = resultsEl.scrollTop;
       const rowTop = row.offsetTop - resultsEl.offsetTop;
       const rowBottom = rowTop + row.offsetHeight;
-      if (align) {
-        alignedRow = row;
-        // #687 -- John: "I would like all down arrow activity to align with the
-        // top every time it's pressed". Minimal scrolling left the selection
-        // pinned to the BOTTOM edge once it got there, so arrowing read as "the
-        // list is stuck" even though the panel kept changing. Pinning the row to
-        // the top moves the list one row per press, and the browser clamps
-        // scrollTop at the end -- which is the "page to the next set of choices"
-        // John asked for as the last rows come into range.
-        resultsEl.scrollTop = rowTop;
-      } else if (rowTop < listTop) resultsEl.scrollTop = rowTop;
+      if (rowTop < listTop) resultsEl.scrollTop = rowTop;
       else if (rowBottom > listTop + resultsEl.clientHeight) {
         resultsEl.scrollTop = rowBottom - resultsEl.clientHeight;
       }
@@ -1527,29 +1500,32 @@
       i = i < 0 ? (delta > 0 ? 0 : rows.length - 1) : i + delta;
       if (i < 0) i = 0;
       if (i > rows.length - 1) i = rows.length - 1;
-      selectRow(rows[i], { align: true });
+      selectRow(rows[i]);
     }
 
     resultsEl.addEventListener('keydown', (e) => {
+      if (['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(e.key)) selectedByKeyboard = true;
       if (e.key === 'ArrowDown') { e.preventDefault(); moveSelection(1); }
       else if (e.key === 'ArrowUp') { e.preventDefault(); moveSelection(-1); }
-      else if (e.key === 'Home') { e.preventDefault(); selectRow(rowsInOrder()[0], { align: true }); }
-      else if (e.key === 'End') { e.preventDefault(); const r = rowsInOrder(); selectRow(r[r.length - 1], { align: true }); }
+      else if (e.key === 'Home') { e.preventDefault(); selectRow(rowsInOrder()[0]); }
+      else if (e.key === 'End') { e.preventDefault(); const r = rowsInOrder(); selectRow(r[r.length - 1]); }
     });
 
     // Down from the search box drops into the list, so the keyboard path works
     // straight from typing without an intervening Tab.
     input.addEventListener('keydown', (e) => {
       if (e.key === 'ArrowDown') {
+        selectedByKeyboard = true;
         e.preventDefault();
         const rows = rowsInOrder();
-        if (rows.length) selectRow(rows[0], { align: true });
+        if (rows.length) selectRow(rows[0]);
       }
     });
 
     resultsEl.addEventListener('click', (e) => {
       const btn = e.target.closest('.behaviors-search-results__row');
       if (!btn) return;
+      selectedByKeyboard = false;
       if (btn.dataset.browseToken) {
         // #664: render it, and LEAVE THE LIST ALONE. Filling the input would
         // re-run applyFilter and collapse the browse list to just this one

--- a/project-index.html
+++ b/project-index.html
@@ -7,8 +7,8 @@
     <title>Project Index</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
-    <link rel="stylesheet" href="src/styles/themes.css?v=95b455f">
-    <link rel="stylesheet" href="src/styles/site.css?v=95b455f">
+    <link rel="stylesheet" href="src/styles/themes.css?v=85a5df7">
+    <link rel="stylesheet" href="src/styles/site.css?v=85a5df7">
     <script type="module">
       import WB from './src/core/wb.js';
       WB.init({ autoInject: true });

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -3,7 +3,7 @@
  * Regenerated on every commit via .husky/pre-commit.
  */
 export const VERSION = {
-  "version": "3.0.51",
-  "commit": "95b455f",
-  "builtAt": "2026-08-20T23:23:58.084Z"
+  "version": "3.0.52",
+  "commit": "85a5df7",
+  "builtAt": "2026-08-21T00:34:11.725Z"
 };

--- a/tests/behaviors/behaviors-browse-navigation.spec.ts
+++ b/tests/behaviors/behaviors-browse-navigation.spec.ts
@@ -86,88 +86,6 @@ test.describe('#686 — two-column layout still does not scroll', () => {
   });
 });
 
-test.describe('#687 — arrow keys align the selection to the top of the list', () => {
-  test.use({ viewport: { width: 1280, height: 900 } });
-
-  test('each ArrowDown puts the selected row at the top of the list viewport', async ({ page }) => {
-    await loadBrowse(page, 'x-');
-
-    await page.locator('.behaviors-search-results__row').first().focus();
-
-    const offsets: number[] = [];
-    for (let i = 0; i < 5; i++) {
-      await page.keyboard.press('ArrowDown');
-      await page.waitForTimeout(120);
-      offsets.push(await page.evaluate(() => {
-        const list = document.getElementById('behaviors-search-results')!;
-        const cur = list.querySelector('[aria-current="true"]') as HTMLElement;
-        return Math.round((cur.offsetTop - list.offsetTop) - list.scrollTop);
-      }));
-    }
-
-    for (const [i, delta] of offsets.entries()) {
-      expect(Math.abs(delta), `press ${i + 1}: selected row sat ${delta}px from the top`).toBeLessThanOrEqual(2);
-    }
-  });
-
-  test('ArrowUp aligns to the top as well', async ({ page }) => {
-    await loadBrowse(page, 'x-');
-    await page.locator('.behaviors-search-results__row').first().focus();
-    for (let i = 0; i < 6; i++) { await page.keyboard.press('ArrowDown'); }
-    await page.waitForTimeout(150);
-    await page.keyboard.press('ArrowUp');
-    await page.waitForTimeout(150);
-
-    const delta = await page.evaluate(() => {
-      const list = document.getElementById('behaviors-search-results')!;
-      const cur = list.querySelector('[aria-current="true"]') as HTMLElement;
-      return Math.round((cur.offsetTop - list.offsetTop) - list.scrollTop);
-    });
-    expect(Math.abs(delta)).toBeLessThanOrEqual(2);
-  });
-
-  test('End reaches the last row and leaves it fully visible', async ({ page }) => {
-    await loadBrowse(page, 'x-');
-    await page.locator('.behaviors-search-results__row').first().focus();
-    await page.keyboard.press('End');
-    await page.waitForTimeout(250);
-
-    const end = await page.evaluate(() => {
-      const list = document.getElementById('behaviors-search-results')!;
-      const rows = [...list.querySelectorAll('.behaviors-search-results__row')];
-      const cur = list.querySelector('[aria-current="true"]') as HTMLElement;
-      const cb = cur.getBoundingClientRect(), lb = list.getBoundingClientRect();
-      return {
-        isLast: rows.indexOf(cur) === rows.length - 1,
-        // #717 replaced "scrolled to the very bottom" as the measure of End.
-        // With trailing room below the last row, End puts that row at the TOP,
-        // which is deliberately NOT max scroll any more -- asserting atBottom
-        // would now be asserting the bug John reported ("the current selection
-        // must be the first one").
-        offsetFromTop: Math.round((cur.offsetTop - list.offsetTop) - list.scrollTop),
-        fullyVisible: cb.top >= lb.top - 2 && cb.bottom <= lb.bottom + 2,
-      };
-    });
-
-    expect(end.isLast, 'End must select the last row').toBe(true);
-    expect(Math.abs(end.offsetFromTop), 'End must put the last row at the TOP of the list (#717)')
-      .toBeLessThanOrEqual(2);
-    expect(end.fullyVisible, 'the last row must be fully in the list viewport').toBe(true);
-  });
-
-  test('clicking a row leaves the list scroll exactly where the reader put it', async ({ page }) => {
-    await loadBrowse(page, 'x-');
-    await page.evaluate(() => { document.getElementById('behaviors-search-results')!.scrollTop = 500; });
-    await page.waitForTimeout(80);
-
-    const rows = page.locator('.behaviors-search-results__row');
-    await rows.nth(12).click();
-    await page.waitForTimeout(300);
-
-    const after = await page.evaluate(() => document.getElementById('behaviors-search-results')!.scrollTop);
-    expect(Math.round(after), 'a click must not yank the list').toBe(500);
-  });
-});
 
 test.describe('#699 — the token column never wraps and never crosses the variant column', () => {
   test.use({ viewport: { width: 1280, height: 900 } });
@@ -305,63 +223,6 @@ test.describe('#711 — the example is centred in the stage', () => {
   }
 });
 
-test.describe('#717 — the selection is the first row anywhere in the list', () => {
-  test.use({ viewport: { width: 1280, height: 900 } });
-
-  for (const filter of ['button', 'x-'] as const) {
-    test(`"${filter}": Down, End and Up all leave the selection at the top`, async ({ page }) => {
-      test.setTimeout(120_000);
-      await loadBrowse(page, filter);
-
-      const worst = await page.evaluate(async () => {
-        const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-        const list = document.getElementById('behaviors-search-results')!;
-        const rows = [...list.querySelectorAll('.behaviors-search-results__row')] as HTMLElement[];
-        const press = (key: string) =>
-          list.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
-        const offset = () => {
-          const cur = list.querySelector('[aria-current="true"]') as HTMLElement;
-          return Math.round((cur.offsetTop - list.offsetTop) - list.scrollTop);
-        };
-
-        rows[0].focus();
-        let down = 0;
-        for (let i = 0; i < 6; i++) { press('ArrowDown'); await sleep(160); down = Math.max(down, Math.abs(offset())); }
-
-        // End is the case that used to fail worst: scrollTop clamps at
-        // scrollHeight - clientHeight, so the last screenful could never reach
-        // the top -- measured 1134px down before the trailing room was added.
-        press('End');
-        await sleep(400);
-        const end = Math.abs(offset());
-
-        let up = 0;
-        for (let i = 0; i < 6; i++) { press('ArrowUp'); await sleep(160); up = Math.max(up, Math.abs(offset())); }
-
-        return { rows: rows.length, down, end, up };
-      });
-
-      expect(worst.rows, 'expected rows to walk').toBeGreaterThan(5);
-      expect(worst.down, 'ArrowDown must pin the selection to the top').toBeLessThanOrEqual(2);
-      expect(worst.end, 'End must put the LAST row at the top').toBeLessThanOrEqual(2);
-      expect(worst.up, 'ArrowUp must pin the selection to the top').toBeLessThanOrEqual(2);
-    });
-  }
-
-  test('a list too short to scroll gains no trailing padding', async ({ page }) => {
-    await loadBrowse(page, 'x-globe');   // a single behavior
-    await page.waitForTimeout(500);
-    const state = await page.evaluate(() => {
-      const list = document.getElementById('behaviors-search-results')!;
-      return {
-        rows: list.querySelectorAll('.behaviors-search-results__row').length,
-        padding: list.style.paddingBottom,
-      };
-    });
-    expect(state.rows, 'expected a short list').toBeLessThan(5);
-    expect(state.padding, 'nothing to scroll — no padding needed').toBe('');
-  });
-});
 
 test.describe('#720 — the stage can go fullscreen and come back unchanged', () => {
   test.use({ viewport: { width: 1280, height: 900 } });
@@ -436,3 +297,97 @@ test.describe('#720 — the stage can go fullscreen and come back unchanged', ()
     expect(trip.example, 'the example must survive the round trip').toBe(true);
   });
 });
+
+test.describe('#728 — arrow keys move the selection, the list stays put', () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test('a selection already on screen does not scroll the list', async ({ page }) => {
+    await loadBrowse(page, 'x-');
+
+    const walk = await page.evaluate(async () => {
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      const list = document.getElementById('behaviors-search-results')!;
+      const rows = [...list.querySelectorAll('.behaviors-search-results__row')] as HTMLElement[];
+      const press = (key: string) => list.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+      const state = () => {
+        const cur = list.querySelector('[aria-current="true"]') as HTMLElement;
+        const rb = cur.getBoundingClientRect(), lb = list.getBoundingClientRect();
+        return {
+          scrollTop: Math.round(list.scrollTop),
+          visible: rb.top >= lb.top - 1 && rb.bottom <= lb.bottom + 1,
+        };
+      };
+      rows[0].focus();
+      const out = [];
+      for (let i = 0; i < 8; i++) { press('ArrowDown'); await sleep(120); out.push(state()); }
+      return { out, padding: list.style.paddingBottom };
+    });
+
+    expect(walk.out.every((s) => s.visible), 'the selected row must stay visible').toBe(true);
+    expect(walk.out.every((s) => s.scrollTop === 0),
+      'the list must not move while the selection is already on screen (#728 replaced #687 align-to-top)').toBe(true);
+    expect(walk.padding, 'no trailing padding — that existed only for align-to-top (#717)').toBe('');
+  });
+
+  test('it scrolls by the minimum once the selection would leave the viewport', async ({ page }) => {
+    test.setTimeout(120_000);
+    await loadBrowse(page, 'x-');
+
+    const result = await page.evaluate(async () => {
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      const list = document.getElementById('behaviors-search-results')!;
+      const rows = [...list.querySelectorAll('.behaviors-search-results__row')] as HTMLElement[];
+      const press = (key: string) => list.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+      const state = () => {
+        const cur = list.querySelector('[aria-current="true"]') as HTMLElement;
+        const rb = cur.getBoundingClientRect(), lb = list.getBoundingClientRect();
+        return {
+          scrollTop: Math.round(list.scrollTop),
+          visible: rb.top >= lb.top - 1 && rb.bottom <= lb.bottom + 1,
+          fromTop: Math.round(rb.top - lb.top),
+        };
+      };
+      rows[0].focus();
+      const scrolls = [];
+      for (let i = 0; i < 40 && scrolls.length < 4; i++) {
+        press('ArrowDown');
+        await sleep(80);
+        const s = state();
+        if (s.scrollTop > 0) scrolls.push(s);
+      }
+      press('End');
+      await sleep(400);
+      // PITCH, not height: rows sit 5px apart, so one row of scroll is
+      // offsetHeight + gap. Measuring height alone made the assertion fail at
+      // 55px for a 50px row -- the behavior was right, the tolerance was wrong.
+      const pitch = rows.length > 1
+        ? Math.round(rows[1].offsetTop - rows[0].offsetTop)
+        : Math.round(rows[0].offsetHeight);
+      return { scrolls, end: state(), rowPitch: pitch };
+    });
+
+    expect(result.scrolls.length, 'expected the list to start scrolling eventually').toBeGreaterThan(2);
+    expect(result.scrolls.every((s) => s.visible), 'the selection stays visible while scrolling').toBe(true);
+
+    // Minimum scroll = about one row per press, and the row sits at the BOTTOM
+    // edge — not pulled to the top.
+    const steps = result.scrolls.slice(1).map((s, i) => s.scrollTop - result.scrolls[i].scrollTop);
+    for (const step of steps) {
+      expect(step, `scrolled ${step}px for one row pitch of ${result.rowPitch}px`)
+        .toBeLessThanOrEqual(result.rowPitch + 2);
+    }
+
+    expect(result.end.visible, 'End must leave the last row visible').toBe(true);
+  });
+
+  test('clicking a row still leaves the list scroll where the reader put it', async ({ page }) => {
+    await loadBrowse(page, 'x-');
+    await page.evaluate(() => { document.getElementById('behaviors-search-results')!.scrollTop = 500; });
+    await page.waitForTimeout(80);
+    await page.locator('.behaviors-search-results__row').nth(12).click();
+    await page.waitForTimeout(300);
+    const after = await page.evaluate(() => document.getElementById('behaviors-search-results')!.scrollTop);
+    expect(Math.round(after), 'a click must not move the list').toBe(500);
+  });
+});
+


### PR DESCRIPTION
> **John**, having used it: "set it to normal action on key up and or down. I don't like the always at top stuff."

Reverses #687 and #717. Arrow keys move the selection; the list scrolls **only when the row would otherwise be out of view**, by the minimum needed.

Measured on the full 585-row list:

| | |
|---|---|
| rows 1–20 | list stays at `scrollTop: 0` — nothing moves |
| from row 21 | one row pitch per press: 37 → 92 → 146 → 201, row at the bottom edge |
| End | last row selected and visible |

**Removed with it:** the align branch and its four call sites, `syncTailRoom()` (44 lines whose only purpose was letting the last rows reach the top — with normal scrolling it would leave a screen-height gap under the list), and `realignAligned()`.

## Two real things the tests caught on the way

1. After `End`, the panel resize that follows every render (#710) left the last row **out of view** — `selectRow()` had already scrolled by then. `keepSelectionVisible()` re-asserts visibility after the resize, by the same minimum-scroll rule. No pinning.
2. That re-assert then broke #664's contract that a **click** leaves the list where the reader put it — the post-click resize dragged the list to a row they'd deliberately scrolled past. It's keyboard-only now.

## Tests rewritten, not deleted

The #687/#717 tests asserted *distance from the top* — the behavior being removed. The claim is now "the selection stays visible, and the list doesn't move when it doesn't need to":

- [x] 8 presses with the selection on screen → `scrollTop` never changes, row always visible
- [x] past the fold → scrolls by ≤ one row pitch per press, selection stays visible
- [x] `End` leaves the last row visible
- [x] a click still leaves the list exactly where the reader put it
- [x] no trailing padding

One of my own assertions was wrong too: it compared scroll steps against `offsetHeight` (50px) when rows sit 5px apart, so a correct 55px step failed. It measures row **pitch** now.

`behaviors-browse-navigation` — **14/14**.

Closes #728