### PR TITLE
fix(#724,#730): boot once, and make a duplicate id a real runtime error

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,15 +27,15 @@
   <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
 
   <!-- Layer 1: Foundation (render-blocking, already highest priority — no preload needed) -->
-  <link rel="stylesheet" href="src/styles/normalize.css?v=85a5df7">
-  <link rel="stylesheet" href="src/styles/themes.css?v=85a5df7">
-  <link rel="stylesheet" href="src/styles/site.css?v=85a5df7">
-  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=85a5df7">
-  <link rel="modulepreload" href="src/core/wb.js?v=85a5df7">
-  <link rel="modulepreload" href="src/core/site-engine.js?v=85a5df7">
+  <link rel="stylesheet" href="src/styles/normalize.css?v=5b544d3">
+  <link rel="stylesheet" href="src/styles/themes.css?v=5b544d3">
+  <link rel="stylesheet" href="src/styles/site.css?v=5b544d3">
+  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=5b544d3">
+  <link rel="modulepreload" href="src/core/wb.js?v=5b544d3">
+  <link rel="modulepreload" href="src/core/site-engine.js?v=5b544d3">
 
   <!-- Page Transitions CSS -->
-  <link rel="stylesheet" href="src/styles/transitions.css?v=85a5df7">
+  <link rel="stylesheet" href="src/styles/transitions.css?v=5b544d3">
   <!-- Navbar CSS already loads via site.css's own @import — no separate link needed. -->
 
   <!-- Fonts -->
@@ -92,9 +92,9 @@
   </template>
 
   <!-- Premium Navbar Scroll Effect -->
-  <script src="src/lib/premium-navbar.js?v=85a5df7"></script>
+  <script src="src/lib/premium-navbar.js?v=5b544d3"></script>
 
   <!-- Main Application Bootstrap -->
-  <script type="module" src="./src/main.js?v=85a5df7"></script>
+  <script type="module" src="./src/main.js?v=5b544d3"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wb-starter",
-  "version": "3.0.52",
+  "version": "3.0.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wb-starter",
-      "version": "3.0.52",
+      "version": "3.0.53",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wb-starter",
-  "version": "3.0.52",
+  "version": "3.0.53",
   "type": "module",
   "description": "Modern website starter kit powered by WB Behaviors",
   "main": "index.html",

--- a/project-index.html
+++ b/project-index.html
@@ -7,8 +7,8 @@
     <title>Project Index</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
-    <link rel="stylesheet" href="src/styles/themes.css?v=85a5df7">
-    <link rel="stylesheet" href="src/styles/site.css?v=85a5df7">
+    <link rel="stylesheet" href="src/styles/themes.css?v=5b544d3">
+    <link rel="stylesheet" href="src/styles/site.css?v=5b544d3">
     <script type="module">
       import WB from './src/core/wb.js';
       WB.init({ autoInject: true });

--- a/src/core/duplicate-ids.js
+++ b/src/core/duplicate-ids.js
@@ -1,0 +1,77 @@
+/**
+ * duplicate-ids.js (#730)
+ *
+ * John: "if all elements on the page have an id then duplicate work would have
+ * a run time error."
+ *
+ * #724 rendered the whole SPA twice — two navbars, two sidebars, two heroes —
+ * and said nothing. Everything "worked", twice, and every getElementById
+ * quietly returned the first of two. The only reason anyone knew was that
+ * somebody looked at the screen.
+ *
+ * Every element the showcase renders carries an id (#675), so duplicate ids are
+ * a precise signal that something rendered twice — and they are invalid HTML in
+ * any case. This turns that silence into a real, logged runtime error.
+ *
+ * It reports; it never breaks the page. A detector that can take the site down
+ * is worse than the bug it watches for.
+ */
+import { logError } from './error-logger.js';
+
+/** Ids the page legitimately repeats, if any ever need to be tolerated. */
+const ALLOWED = new Set();
+
+/**
+ * Every id that appears more than once, as `{ id, count }`, worst first.
+ * @param {ParentNode} [root=document]
+ */
+export function findDuplicateIds(root = document) {
+  const counts = new Map();
+  for (const el of root.querySelectorAll('[id]')) {
+    const id = el.id;
+    if (!id || ALLOWED.has(id)) continue;
+    counts.set(id, (counts.get(id) || 0) + 1);
+  }
+  return [...counts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([id, count]) => ({ id, count }))
+    .sort((a, b) => b.count - a.count);
+}
+
+/**
+ * Check the document and raise a logged runtime error if anything is doubled.
+ * @param {string} when - what had just happened, so the log says where to look
+ * @returns {{id: string, count: number}[]} the duplicates found (empty when clean)
+ */
+export function reportDuplicateIds(when = 'render') {
+  let duplicates = [];
+  try {
+    duplicates = findDuplicateIds();
+    if (!duplicates.length) return duplicates;
+
+    const summary = duplicates.slice(0, 10)
+      .map((d) => `#${d.id} x${d.count}`)
+      .join(', ');
+    const more = duplicates.length > 10 ? ` (+${duplicates.length - 10} more)` : '';
+    const message =
+      `Duplicate element id(s) ${when}: ${summary}${more}. ` +
+      'An id appearing twice means something rendered twice — see #724/#730. ' +
+      'Every getElementById for these returns the first copy only.';
+
+    // A real error, not a console.warn: warnings get scrolled past, and this
+    // one needs to reach the Error Log page like any other runtime failure.
+    console.error('[WB:DUPLICATE-ID]', message);
+    void logError(message, {
+      source: 'duplicate-ids',
+      when,
+      duplicates: duplicates.slice(0, 25),
+      total: duplicates.length,
+    });
+  } catch (err) {
+    // Never let the detector be the thing that breaks the page.
+    console.warn('[WB] duplicate-id check failed', err);
+  }
+  return duplicates;
+}
+
+export default { findDuplicateIds, reportDuplicateIds };

--- a/src/core/site-engine.js
+++ b/src/core/site-engine.js
@@ -609,6 +609,17 @@ export default class WBSite {
           // Small delay to ensure DOM is fully updated
           setTimeout(() => window.WB.scan(main), 10);
         }
+
+        // #730 -- John: "if all elements on the page have an id then duplicate
+        // work would have a run time error." Checked AFTER the old page has been
+        // replaced and the new one scanned, so a normal navigation never trips
+        // it -- only genuine duplication does. Dynamic import so a page render
+        // never waits on the detector, and never fails because of it.
+        setTimeout(() => {
+          import('./duplicate-ids.js')
+            .then((m) => m.reportDuplicateIds(`after navigating to ${pageId}`))
+            .catch(() => { /* the detector is never allowed to break a render */ });
+        }, 400);
       } else {
         main.innerHTML = this.render404(pageId);
       }

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -3,7 +3,7 @@
  * Regenerated on every commit via .husky/pre-commit.
  */
 export const VERSION = {
-  "version": "3.0.52",
-  "commit": "85a5df7",
-  "builtAt": "2026-08-21T00:34:11.725Z"
+  "version": "3.0.53",
+  "commit": "5b544d3",
+  "builtAt": "2026-08-21T00:41:03.197Z"
 };

--- a/src/main.js
+++ b/src/main.js
@@ -20,12 +20,36 @@ import WB from './core/wb.js';
 import WBSiteClass from './core/site-engine.js';
 import { VERSION } from './core/version.js';
 import { traceStatusLabel } from './core/debug-trace.js';
+import { reportDuplicateIds } from './core/duplicate-ids.js';
 
 /**
  * Initialize the wb-starter application
  * @returns {Promise<void>}
  */
+/**
+ * #724/#730 -- a second boot silently built a second shell: two navbars, two
+ * sidebars, two heroes, and nothing said a word. init() runs once. A second
+ * call is a no-op, not a second page.
+ *
+ * It is reachable because the boot URL is version-stamped
+ * (`src/main.js?v=<commit>`) and ES modules are keyed by URL, so a tab holding
+ * a cached shell alongside a newer one loads two separate module instances,
+ * each calling init().
+ */
+const BOOT_FLAG = '__wbBooted';
+
 async function init() {
+  // The flag lives on window, NOT in module scope. #724's actual mechanism is
+  // TWO MODULE INSTANCES -- `main.js?v=A` and `main.js?v=B` are different URLs,
+  // so ES modules loads each separately and each gets its own module scope. A
+  // module-level `let booted` would be false in both and guard nothing. The
+  // window is the only thing the two instances share.
+  if (_window[BOOT_FLAG]) {
+    console.warn('[WB] init() called twice — ignoring the second boot (#724). ' +
+      'A second boot builds a second shell: two navbars, two sidebars, two of everything.');
+    return;
+  }
+  _window[BOOT_FLAG] = true;
   // Commit + build time on the very first line — the console log itself is
   // the fastest way to confirm which deploy you're actually looking at,
   // without digging through the header or network tab.
@@ -55,6 +79,12 @@ async function init() {
 
     // Expose for debugging
     _window.WBSite = site;
+
+    // #730 -- John: "if all elements on the page have an id then duplicate work
+    // would have a run time error". Every rendered element carries an id (#675),
+    // so duplicates are a precise signal that something rendered twice -- and
+    // they are invalid HTML regardless. Report loudly; never break the page.
+    reportDuplicateIds('after boot');
 
     console.log('✅ wb-starter ready');
   } catch (error) {

--- a/tests/regression/duplicate-ids-and-single-boot.spec.ts
+++ b/tests/regression/duplicate-ids-and-single-boot.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * #724 / #730 — the page must boot once, and duplicate ids must be loud.
+ *
+ * John, on a screenshot of the site rendered twice: "why are two things
+ * showing?" — two navbars, two sidebars, two heroes. Everything "worked",
+ * twice, and every getElementById quietly returned the first of two. The only
+ * reason anyone knew was that he looked at the screen.
+ *
+ * Then: "if all elements on the page have an id then duplicate work would have
+ * a run time error." That is what this pins.
+ *
+ * The mechanism is reproduced here directly rather than described: importing
+ * `main.js` under a second URL creates a second MODULE INSTANCE with its own
+ * module scope — which is exactly what a stale `?v=<commit>` shell does — and
+ * that second instance calls init() again.
+ */
+import { test, expect, Page } from '@playwright/test';
+
+async function loadSite(page: Page) {
+  await page.goto('/?page=behaviors');
+  await page.waitForSelector('#behaviors-search', { timeout: 30000 });
+  await page.waitForTimeout(1200);
+}
+
+test.describe('#724 — the site boots exactly once', () => {
+  test('a fresh load has one shell and no duplicate ids', async ({ page }) => {
+    await loadSite(page);
+
+    const state = await page.evaluate(async () => {
+      const mod: any = await import('/src/core/duplicate-ids.js');
+      return {
+        app: document.querySelectorAll('#app').length,
+        siteBody: document.querySelectorAll('#siteBody').length,
+        main: document.querySelectorAll('#main').length,
+        duplicates: mod.findDuplicateIds(),
+      };
+    });
+
+    expect(state.app, 'one #app').toBe(1);
+    expect(state.siteBody, 'one #siteBody').toBe(1);
+    expect(state.main, 'one #main').toBe(1);
+    expect(state.duplicates, 'a clean page has no duplicate ids').toEqual([]);
+  });
+
+  test('a SECOND module instance does not build a second shell', async ({ page }) => {
+    await loadSite(page);
+
+    const result = await page.evaluate(async () => {
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      const warnings: string[] = [];
+      const origWarn = console.warn;
+      console.warn = (...a: any[]) => { warnings.push(a.join(' ')); origWarn(...a); };
+
+      // A different URL = a different module = its own module scope. This is
+      // why the boot flag has to live on window: a module-level `let` would be
+      // false in both instances and guard nothing.
+      await import('/src/main.js?v=second-instance-probe');
+      await sleep(2500);
+      console.warn = origWarn;
+
+      const mod: any = await import('/src/core/duplicate-ids.js');
+      return {
+        app: document.querySelectorAll('#app').length,
+        siteBody: document.querySelectorAll('#siteBody').length,
+        blocked: warnings.some((w) => w.includes('called twice')),
+        duplicates: mod.findDuplicateIds(),
+      };
+    });
+
+    expect(result.blocked, 'the second boot must be refused, and say so').toBe(true);
+    expect(result.app, 'still one #app after a second module instance').toBe(1);
+    expect(result.siteBody, 'still one #siteBody').toBe(1);
+    expect(result.duplicates, 'and therefore still no duplicate ids').toEqual([]);
+  });
+});
+
+test.describe('#730 — a duplicate id is a runtime error', () => {
+  test('an injected duplicate is detected and reported as an error', async ({ page }) => {
+    await loadSite(page);
+
+    const result = await page.evaluate(async () => {
+      const mod: any = await import('/src/core/duplicate-ids.js');
+
+      const probe = document.createElement('div');
+      probe.id = 'behaviors-live-stage';        // clashes with the real one
+      document.body.appendChild(probe);
+
+      const errors: string[] = [];
+      const origError = console.error;
+      console.error = (...a: any[]) => { errors.push(a.join(' ')); origError(...a); };
+      const found = mod.reportDuplicateIds('probe');
+      console.error = origError;
+
+      probe.remove();
+      const afterRemoval = mod.findDuplicateIds();
+      return { found, errors, afterRemoval };
+    });
+
+    expect(result.found.length, 'the duplicate must be found').toBe(1);
+    expect(result.found[0].id).toBe('behaviors-live-stage');
+    expect(result.found[0].count).toBe(2);
+    expect(
+      result.errors.some((e) => e.includes('DUPLICATE-ID') && e.includes('behaviors-live-stage')),
+      'it must be a console.error naming the id — a warning gets scrolled past',
+    ).toBe(true);
+    expect(result.afterRemoval, 'and clean again once the duplicate is gone').toEqual([]);
+  });
+
+  test('the detector never breaks the page', async ({ page }) => {
+    await loadSite(page);
+
+    const stillAlive = await page.evaluate(async () => {
+      const mod: any = await import('/src/core/duplicate-ids.js');
+      // Hand it something hostile; it must swallow, not throw.
+      let threw = false;
+      try { mod.reportDuplicateIds(undefined as any); } catch { threw = true; }
+      return {
+        threw,
+        searchStillThere: !!document.getElementById('behaviors-search'),
+        rows: document.querySelectorAll('.behaviors-search-results__row').length,
+      };
+    });
+
+    expect(stillAlive.threw, 'the detector must never throw into the page').toBe(false);
+    expect(stillAlive.searchStillThere, 'the page must still be alive after a check').toBe(true);
+  });
+});


### PR DESCRIPTION
> **John:** "if all elements on the page have an id then duplicate work would have a run time error"

Right — and it's the missing half of #724. The site rendered twice and **said nothing**. Everything worked, twice, and every `getElementById` quietly returned the first of two copies.

## #724 — the guard, and why it lives on `window`

The actual mechanism is **two module instances**. `main.js?v=A` and `main.js?v=B` are different URLs, so ES modules loads each separately, each with its own module scope. A module-level `let booted` would be `false` in both and guard nothing. The window is the only thing they share.

I wrote it module-scoped first, realised it couldn't work for the case it targets, and moved it.

**Reproduced directly rather than theorised** — importing `main.js` under a second URL used to build a second shell. Now:

```
[WB] init() called twice — ignoring the second boot (#724).
#app: 1   #siteBody: 1   hero: 1   duplicate ids: 0
```

## #730 — duplicates are loud

`src/core/duplicate-ids.js` reports every repeated id as a `console.error` routed through `logError()`, so it lands in the **Error Log page** like any other runtime failure. A `console.warn` gets scrolled past — that's how the double render survived in the first place.

It runs after boot and after each navigation — once the old page is gone and the new one is scanned, so a normal navigation never trips it — and it's wrapped so **the detector can never be the thing that breaks a render**.

Measured:

| | |
|---|---|
| clean page | 0 duplicates |
| inject one | `#behaviors-live-stage x2`, reported with its count |
| remove it | clean again |

## Test plan

`tests/regression/duplicate-ids-and-single-boot.spec.ts` — **4/4**

- [x] fresh load: one `#app`, one `#siteBody`, one `#main`, zero duplicate ids
- [x] a second module instance is refused and says so; still one shell
- [x] an injected duplicate is reported as an error naming the id and count
- [x] the detector never throws into the page

Closes #724
Closes #730