### PR TITLE
fix(#725): pages that exist are reachable by URL — the footer links work again

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,15 +27,15 @@
   <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
 
   <!-- Layer 1: Foundation (render-blocking, already highest priority — no preload needed) -->
-  <link rel="stylesheet" href="src/styles/normalize.css?v=5b544d3">
-  <link rel="stylesheet" href="src/styles/themes.css?v=5b544d3">
-  <link rel="stylesheet" href="src/styles/site.css?v=5b544d3">
-  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=5b544d3">
-  <link rel="modulepreload" href="src/core/wb.js?v=5b544d3">
-  <link rel="modulepreload" href="src/core/site-engine.js?v=5b544d3">
+  <link rel="stylesheet" href="src/styles/normalize.css?v=2050c0f">
+  <link rel="stylesheet" href="src/styles/themes.css?v=2050c0f">
+  <link rel="stylesheet" href="src/styles/site.css?v=2050c0f">
+  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=2050c0f">
+  <link rel="modulepreload" href="src/core/wb.js?v=2050c0f">
+  <link rel="modulepreload" href="src/core/site-engine.js?v=2050c0f">
 
   <!-- Page Transitions CSS -->
-  <link rel="stylesheet" href="src/styles/transitions.css?v=5b544d3">
+  <link rel="stylesheet" href="src/styles/transitions.css?v=2050c0f">
   <!-- Navbar CSS already loads via site.css's own @import — no separate link needed. -->
 
   <!-- Fonts -->
@@ -92,9 +92,9 @@
   </template>
 
   <!-- Premium Navbar Scroll Effect -->
-  <script src="src/lib/premium-navbar.js?v=5b544d3"></script>
+  <script src="src/lib/premium-navbar.js?v=2050c0f"></script>
 
   <!-- Main Application Bootstrap -->
-  <script type="module" src="./src/main.js?v=5b544d3"></script>
+  <script type="module" src="./src/main.js?v=2050c0f"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wb-starter",
-  "version": "3.0.53",
+  "version": "3.0.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wb-starter",
-      "version": "3.0.53",
+      "version": "3.0.54",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wb-starter",
-  "version": "3.0.53",
+  "version": "3.0.54",
   "type": "module",
   "description": "Modern website starter kit powered by WB Behaviors",
   "main": "index.html",

--- a/project-index.html
+++ b/project-index.html
@@ -7,8 +7,8 @@
     <title>Project Index</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
-    <link rel="stylesheet" href="src/styles/themes.css?v=5b544d3">
-    <link rel="stylesheet" href="src/styles/site.css?v=5b544d3">
+    <link rel="stylesheet" href="src/styles/themes.css?v=2050c0f">
+    <link rel="stylesheet" href="src/styles/site.css?v=2050c0f">
     <script type="module">
       import WB from './src/core/wb.js';
       WB.init({ autoInject: true });

--- a/src/core/site-engine.js
+++ b/src/core/site-engine.js
@@ -45,7 +45,14 @@ export default class WBSite {
       
       const params = new URLSearchParams(window.location.search);
       const pageParam = params.get('page');
-      if (pageParam && this.config.navigationMenu.find(n => n.menuItemId === pageParam)) {
+      // #725 -- the SECOND copy of the same wrong rule. This one dropped the
+      // ?page= parameter on the floor whenever it was not a nav menu item, so
+      // currentPage stayed 'home' and navigateTo() never even saw the request.
+      // Fixing only the gate inside navigateTo() changed nothing: ?page=privacy
+      // still rendered home, because it never got that far. Same test as there:
+      // a plausible page id is accepted, and whether the page EXISTS is decided
+      // by the fetch, which already has a 404 path.
+      if (pageParam && /^[a-z0-9][a-z0-9-]*$/i.test(pageParam)) {
         this.currentPage = pageParam;
       }
 
@@ -543,9 +550,24 @@ export default class WBSite {
     if (window.innerWidth <= 768) {
       this.closeMobileNav();
     }
+
+    let main_notFound = false;
     
-    if (!this.config.navigationMenu.find(n => n.menuItemId === pageId)) {
-      pageId = 'home';
+    // #725 -- John's own footer links were broken by this. The gate used to be
+    //   if (!navigationMenu.find(n => n.menuItemId === pageId)) pageId = 'home';
+    // so ANY page that is not a nav menu item silently became home: 10 of the
+    // 20 files in pages/ were unreachable by URL, including ?page=privacy and
+    // ?page=terms, which the footer links to on every page of the site. No
+    // error, no 404, the URL still saying privacy while home rendered.
+    //
+    // The fetch below already handles a missing page properly -- render404() --
+    // so the nav list is the wrong authority for "does this page exist". What
+    // the gate WAS doing accidentally was keeping junk out of the fetch path,
+    // since pageId is interpolated straight into `pages/${pageId}.html`. That
+    // job is now done deliberately, and only that job.
+    if (!/^[a-z0-9][a-z0-9-]*$/i.test(pageId)) {
+      console.warn(`[WBSite] refusing to navigate to an invalid page id: ${JSON.stringify(pageId)}`);
+      main_notFound = true;
     }
     if (pageId === 'schema-viewer') {
       window.open('schema-viewer.html', '_blank');
@@ -558,6 +580,10 @@ export default class WBSite {
     this.currentPage = pageId;
     this.updateActiveNav();
     const main = document.getElementById('main');
+    if (main_notFound) {
+      main.innerHTML = this.render404(pageId);
+      return;
+    }
     main.innerHTML = `<div class="page__loading" id="mainPageLoading"><wb-spinner  id="mainSpinner"></div><p id="mainLoadingText">Loading...</p></div>`;
     // Optimization: Don't await scan here to start fetch immediately. MutationObserver handles injection.
     // WB.scan(main); 

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -3,7 +3,7 @@
  * Regenerated on every commit via .husky/pre-commit.
  */
 export const VERSION = {
-  "version": "3.0.53",
-  "commit": "5b544d3",
-  "builtAt": "2026-08-21T00:41:03.197Z"
+  "version": "3.0.54",
+  "commit": "2050c0f",
+  "builtAt": "2026-08-21T00:56:52.314Z"
 };

--- a/tests/pages/hero-variants-page.spec.ts
+++ b/tests/pages/hero-variants-page.spec.ts
@@ -8,7 +8,10 @@ test.describe('Hero Variants Page', () => {
   });
 
   test('page loads successfully', async ({ page }) => {
-    const hero = page.locator('.page__hero, #herovariants-section-1');
+    // #725: the page renders now (it used to silently show home), and it has
+    // BOTH a .page__hero and #herovariants-section-1 -- an unqualified locator
+    // matching two elements is a strict-mode violation, not a page defect.
+    const hero = page.locator('.page__hero, #herovariants-section-1').first();
     await expect(hero).toBeVisible();
     await expect(page.locator('h1').first()).toContainText('Hero Variants');
   });

--- a/tests/regression/non-nav-pages-reachable.spec.ts
+++ b/tests/regression/non-nav-pages-reachable.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * #725 — a page that exists must be reachable by its own URL.
+ *
+ * `navigateTo()` used to rewrite any pageId that was not a NAVIGATION MENU item
+ * to 'home' — silently, URL unchanged, no 404. 10 of the 20 files in pages/
+ * were unreachable, including ?page=privacy and ?page=terms, which the site's
+ * own footer links to on every page.
+ *
+ * The same rule existed twice: once in navigateTo() and once in init(), where
+ * the ?page= parameter was dropped before navigateTo() ever saw it. Fixing one
+ * changed nothing, which is why this test loads pages through the real URL
+ * rather than calling navigateTo() directly — only the URL path exercises both.
+ */
+import { test, expect } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+
+const PAGES_DIR = path.join(process.cwd(), 'pages');
+
+/** Pages that legitimately do not render through the SPA route. */
+const NOT_SPA_ROUTED = new Set([
+  'newpage',                  // template scaffold, not a real page
+  'ai-permutation-test',      // harness
+]);
+
+const pageIds = fs.readdirSync(PAGES_DIR)
+  .filter((f) => f.endsWith('.html'))
+  .map((f) => f.replace(/\.html$/, ''))
+  .filter((id) => !NOT_SPA_ROUTED.has(id));
+
+test.describe('#725 — every page is reachable by URL', () => {
+  for (const id of pageIds) {
+    test(`?page=${id} renders ${id}, not home`, async ({ page }) => {
+      await page.goto(`/?page=${id}`);
+      await page.waitForFunction(() => (window as any).WBSite?.currentPage, { timeout: 25000 });
+      await page.waitForTimeout(900);
+
+      const state = await page.evaluate(() => {
+        const main = document.getElementById('main');
+        const first = main?.firstElementChild as HTMLElement | null;
+        return {
+          currentPage: (window as any).WBSite?.currentPage,
+          container: first?.id || null,
+          is404: !!document.getElementById('empty404'),
+        };
+      });
+
+      expect(state.currentPage, `?page=${id} must not be rewritten`).toBe(id);
+      expect(state.is404, `${id}.html exists, so it must not 404`).toBe(false);
+      expect(state.container, `expected the ${id} page container`).toBe(`mainPage-${id}`);
+    });
+  }
+
+  test('the footer links the reader can actually click land on their pages', async ({ page }) => {
+    await page.goto('/?page=behaviors');
+    await page.waitForSelector('#behaviors-search', { timeout: 25000 });
+
+    const hrefs = await page.evaluate(() =>
+      [...document.querySelectorAll('footer a[href^="?page="]')].map((a) => a.getAttribute('href') || ''),
+    );
+    expect(hrefs.length, 'expected footer page links').toBeGreaterThan(0);
+
+    for (const href of hrefs) {
+      const id = new URLSearchParams(href.replace(/^\?/, '')).get('page');
+      await page.goto(`/${href}`);
+      await page.waitForFunction(() => (window as any).WBSite?.currentPage, { timeout: 25000 });
+      await page.waitForTimeout(700);
+      const landed = await page.evaluate(() => (window as any).WBSite?.currentPage);
+      expect(landed, `footer link ${href} landed on ${landed}`).toBe(id);
+    }
+  });
+});
+
+test.describe('#725 — a page that does not exist says so', () => {
+  test('an unknown page renders the 404 state, not home', async ({ page }) => {
+    await page.goto('/?page=definitely-not-a-page');
+    await page.waitForFunction(() => (window as any).WBSite?.currentPage, { timeout: 25000 });
+    await page.waitForTimeout(900);
+
+    const state = await page.evaluate(() => ({
+      currentPage: (window as any).WBSite?.currentPage,
+      is404: !!document.getElementById('empty404'),
+      isHome: document.getElementById('mainPage-home') !== null,
+    }));
+
+    expect(state.is404, 'a missing page must show the 404 state').toBe(true);
+    expect(state.isHome, 'and must NOT quietly show home').toBe(false);
+  });
+
+  test('an invalid page id is refused before any fetch', async ({ page }) => {
+    await page.goto('/?page=behaviors');
+    await page.waitForSelector('#behaviors-search', { timeout: 25000 });
+
+    const state = await page.evaluate(async () => {
+      const requested: string[] = [];
+      const origFetch = window.fetch;
+      window.fetch = function (input: any, ...rest: any[]) {
+        requested.push(String(typeof input === 'string' ? input : input?.url));
+        return origFetch.call(this, input, ...rest);
+      } as any;
+
+      await (window as any).WBSite.navigateTo('../../etc/passwd');
+      await new Promise((r) => setTimeout(r, 600));
+      window.fetch = origFetch;
+
+      return {
+        is404: !!document.getElementById('empty404'),
+        fetchedTraversal: requested.some((u) => u.includes('..')),
+      };
+    });
+
+    expect(state.fetchedTraversal, 'a traversal id must never reach the fetch').toBe(false);
+    expect(state.is404, 'and it must land on the 404 state').toBe(true);
+  });
+});


### PR DESCRIPTION
`?page=privacy` rendered **home**. So did `?page=terms`, and 8 other pages. No error, no 404, the URL still saying `privacy`. The site's own footer links to both, **on every page**.

## Cause

```js
if (!this.config.navigationMenu.find(n => n.menuItemId === pageId)) pageId = 'home';
```

The **nav menu** was treated as the authority on which pages exist — 11 nav items against 20 files in `pages/`, so 10 were unreachable by URL.

## The rule existed twice, and that mattered

Fixing the copy inside `navigateTo()` changed **nothing** — `?page=privacy` still rendered home, because `init()` drops the `?page=` parameter before `navigateTo()` ever sees it:

```js
if (pageParam && this.config.navigationMenu.find(n => n.menuItemId === pageParam)) {
  this.currentPage = pageParam;     // …otherwise currentPage stays 'home'
}
```

Both are fixed. The test loads pages through the **real URL** rather than calling `navigateTo()` directly, because only the URL path exercises both copies — a test that called `navigateTo()` would have passed against a still-broken site.

The fetch below already handles a missing page (`render404`), so it is the right authority for "does this exist". What the gate was doing *accidentally* was keeping junk out of `pages/${pageId}.html` — that job is now done deliberately with `^[a-z0-9][a-z0-9-]*$`, and only that job.

## Measured after

| URL | result |
|---|---|
| `?page=privacy` | Privacy Policy |
| `?page=terms` | Terms of Service |
| `?page=hero-variants` | Hero Variants — 12 heroes, 11 variant classes + default |
| `?page=services`, `?page=contact` | their own pages |
| `?page=definitely-not-a-page` | the **404 state**, not home |
| `?page=../../etc/passwd` | refused, and never reaches a fetch |

## Test plan

- [x] `non-nav-pages-reachable.spec.ts` — **21/21**: one test per page in `pages/`, plus the footer links followed for real, plus 404 and traversal
- [x] `hero-variants-page.spec.ts` — **4/4**, was 0/4. All four failures in the variants run were this bug, not heroes.

The last hero failure was the spec's own ambiguous locator (`.page__hero, #herovariants-section-1` matches two elements — a strict-mode violation, not a page defect), now qualified with `.first()`.

Closes #725