### PR TITLE
fix(#733): x-fullscreen commits nothing until the request is granted

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,15 +27,15 @@
   <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
 
   <!-- Layer 1: Foundation (render-blocking, already highest priority — no preload needed) -->
-  <link rel="stylesheet" href="src/styles/normalize.css?v=2050c0f">
-  <link rel="stylesheet" href="src/styles/themes.css?v=2050c0f">
-  <link rel="stylesheet" href="src/styles/site.css?v=2050c0f">
-  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=2050c0f">
-  <link rel="modulepreload" href="src/core/wb.js?v=2050c0f">
-  <link rel="modulepreload" href="src/core/site-engine.js?v=2050c0f">
+  <link rel="stylesheet" href="src/styles/normalize.css?v=659dd48">
+  <link rel="stylesheet" href="src/styles/themes.css?v=659dd48">
+  <link rel="stylesheet" href="src/styles/site.css?v=659dd48">
+  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=659dd48">
+  <link rel="modulepreload" href="src/core/wb.js?v=659dd48">
+  <link rel="modulepreload" href="src/core/site-engine.js?v=659dd48">
 
   <!-- Page Transitions CSS -->
-  <link rel="stylesheet" href="src/styles/transitions.css?v=2050c0f">
+  <link rel="stylesheet" href="src/styles/transitions.css?v=659dd48">
   <!-- Navbar CSS already loads via site.css's own @import — no separate link needed. -->
 
   <!-- Fonts -->
@@ -92,9 +92,9 @@
   </template>
 
   <!-- Premium Navbar Scroll Effect -->
-  <script src="src/lib/premium-navbar.js?v=2050c0f"></script>
+  <script src="src/lib/premium-navbar.js?v=659dd48"></script>
 
   <!-- Main Application Bootstrap -->
-  <script type="module" src="./src/main.js?v=2050c0f"></script>
+  <script type="module" src="./src/main.js?v=659dd48"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wb-starter",
-  "version": "3.0.54",
+  "version": "3.0.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wb-starter",
-      "version": "3.0.54",
+      "version": "3.0.55",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wb-starter",
-  "version": "3.0.54",
+  "version": "3.0.55",
   "type": "module",
   "description": "Modern website starter kit powered by WB Behaviors",
   "main": "index.html",

--- a/project-index.html
+++ b/project-index.html
@@ -7,8 +7,8 @@
     <title>Project Index</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
-    <link rel="stylesheet" href="src/styles/themes.css?v=2050c0f">
-    <link rel="stylesheet" href="src/styles/site.css?v=2050c0f">
+    <link rel="stylesheet" href="src/styles/themes.css?v=659dd48">
+    <link rel="stylesheet" href="src/styles/site.css?v=659dd48">
     <script type="module">
       import WB from './src/core/wb.js';
       WB.init({ autoInject: true });

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -3,7 +3,7 @@
  * Regenerated on every commit via .husky/pre-commit.
  */
 export const VERSION = {
-  "version": "3.0.54",
-  "commit": "2050c0f",
-  "builtAt": "2026-08-21T00:56:52.314Z"
+  "version": "3.0.55",
+  "commit": "659dd48",
+  "builtAt": "2026-08-21T01:05:11.350Z"
 };

--- a/src/wb-viewmodels/helpers.js
+++ b/src/wb-viewmodels/helpers.js
@@ -229,22 +229,56 @@ export function fullscreen(element, options = {}) {
   element.onclick = () => {
     if (document.fullscreenElement) {
       document.exitFullscreen();
-    } else {
-      // Store original styles
-      originalStyles = {
-        overflow: targetEl.style.overflow,
-        overflowY: targetEl.style.overflowY,
-        height: targetEl.style.height
-      };
-      
-      // Set styles for scrolling in fullscreen
-      targetEl.style.overflow = 'auto';
-      targetEl.style.overflowY = 'auto';
-      targetEl.style.height = '100vh';
-      
-      targetEl.requestFullscreen();
-      element.textContent = '✕ Exit Fullscreen';
+      return;
     }
+    if (!targetEl) {
+      console.error('[WB:fullscreen] no element matches target', JSON.stringify(config.target));
+      return;
+    }
+
+    // #733 -- John: "fullscreen is not working". Every side effect used to be
+    // committed BEFORE requestFullscreen() settled, and its promise was thrown
+    // away. Measured on a real click: document.fullscreenElement stayed null
+    // while the target had already been stretched to height:100vh and the button
+    // already read "Exit Fullscreen" -- a panel blown up to viewport height, a
+    // control lying about the state, and no error to explain either. The restore
+    // path only runs on `fullscreenchange`, which never fires for a request that
+    // was rejected.
+    //
+    // Request first. Apply the styles and the label only once it resolves.
+    const saved = {
+      overflow: targetEl.style.overflow,
+      overflowY: targetEl.style.overflowY,
+      height: targetEl.style.height
+    };
+
+    let request;
+    try {
+      request = targetEl.requestFullscreen();
+    } catch (err) {
+      console.error(`[WB:fullscreen] request threw: ${err.name}: ${err.message}`);
+      return;
+    }
+
+    Promise.resolve(request)
+      .then(() => {
+        originalStyles = saved;
+        targetEl.style.overflow = 'auto';
+        targetEl.style.overflowY = 'auto';
+        targetEl.style.height = '100vh';
+        element.textContent = '✕ Exit Fullscreen';
+      })
+      .catch((err) => {
+        // Nothing was changed, so there is nothing to undo -- but SAY why.
+        // The reason is the difference between "no user gesture", "blocked by
+        // permissions policy" and "this element cannot be fullscreened", and
+        // swallowing it left the reader with no way to tell them apart.
+        console.error(`[WB:fullscreen] request rejected: ${err && err.name}: ${err && err.message}`);
+        targetEl.style.overflow = saved.overflow;
+        targetEl.style.overflowY = saved.overflowY;
+        targetEl.style.height = saved.height;
+        element.textContent = config.label;
+      });
   };
 
   return () => {

--- a/tests/regression/fullscreen-failure-rollback.spec.ts
+++ b/tests/regression/fullscreen-failure-rollback.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * #733 — x-fullscreen must not commit anything until the request succeeds.
+ *
+ * John: "fullscreen is not working". Measured on a real click: the target had
+ * already been stretched to `height: 100vh` and the button already read
+ * "✕ Exit Fullscreen", while `document.fullscreenElement` was null. A panel
+ * blown up to viewport height, a control lying about the state, and no error
+ * anywhere to explain either — because `requestFullscreen()`'s promise was
+ * thrown away and the restore path only runs on `fullscreenchange`, which never
+ * fires for a request that was rejected.
+ *
+ * The real API is stubbed here on purpose. Whether a given browser or embedder
+ * grants fullscreen is not what is being tested — the contract is: nothing
+ * changes unless it is granted, and a refusal says why.
+ */
+import { test, expect, Page } from '@playwright/test';
+
+async function openExample(page: Page) {
+  await page.goto('/?page=behaviors');
+  await page.waitForSelector('#behaviors-search', { timeout: 30000 });
+  await page.fill('#behaviors-search', 'article');
+  await page.waitForFunction(
+    () => document.querySelectorAll('.behaviors-search-results__row').length > 0,
+    { timeout: 20000 },
+  );
+  await page.locator('.behaviors-search-results__row').first().click();
+  await page.waitForTimeout(600);
+}
+
+test.describe('#733 — a refused fullscreen changes nothing', () => {
+  test('a rejected request leaves styles and label untouched, and says why', async ({ page }) => {
+    await openExample(page);
+
+    const result = await page.evaluate(async () => {
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      const target = document.getElementById('behaviors-live-stage')
+        || document.getElementById('behaviors-live-example');
+      const btn = document.getElementById('behaviors-live-fullscreen') as HTMLElement;
+
+      const before = {
+        height: target!.style.height,
+        overflow: target!.style.overflow,
+        label: btn.textContent!.trim(),
+        rect: Math.round(target!.getBoundingClientRect().height),
+      };
+
+      const errors: string[] = [];
+      const origError = console.error;
+      console.error = (...a: any[]) => { errors.push(a.join(' ')); origError(...a); };
+
+      const origRequest = Element.prototype.requestFullscreen;
+      Element.prototype.requestFullscreen = function () {
+        return Promise.reject(new DOMException('Permissions check failed', 'TypeError'));
+      };
+
+      btn.onclick!(new MouseEvent('click'));
+      await sleep(400);
+
+      Element.prototype.requestFullscreen = origRequest;
+      console.error = origError;
+
+      return {
+        before,
+        after: {
+          height: target!.style.height,
+          overflow: target!.style.overflow,
+          label: btn.textContent!.trim(),
+          rect: Math.round(target!.getBoundingClientRect().height),
+        },
+        reported: errors.some((e) => e.includes('[WB:fullscreen]') && e.includes('Permissions check failed')),
+      };
+    });
+
+    expect(result.after.height, 'a refused request must not stretch the target').toBe(result.before.height);
+    expect(result.after.overflow, 'nor change its overflow').toBe(result.before.overflow);
+    expect(result.after.rect, 'the target must be exactly the size it was').toBe(result.before.rect);
+    expect(result.after.label, 'the button must not claim you are in fullscreen').toBe(result.before.label);
+    expect(result.reported, 'and the reason must be logged, not swallowed').toBe(true);
+  });
+
+  test('a granted request applies the fullscreen styles and label', async ({ page }) => {
+    await openExample(page);
+
+    const result = await page.evaluate(async () => {
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      const target = document.getElementById('behaviors-live-stage')
+        || document.getElementById('behaviors-live-example');
+      const btn = document.getElementById('behaviors-live-fullscreen') as HTMLElement;
+      const labelBefore = btn.textContent!.trim();
+
+      const origRequest = Element.prototype.requestFullscreen;
+      Element.prototype.requestFullscreen = function () { return Promise.resolve(); };
+
+      btn.onclick!(new MouseEvent('click'));
+      await sleep(400);
+      Element.prototype.requestFullscreen = origRequest;
+
+      const applied = {
+        height: target!.style.height,
+        overflow: target!.style.overflow,
+        label: btn.textContent!.trim(),
+      };
+
+      // Coming back out restores what was saved (#720's guarantee).
+      document.dispatchEvent(new Event('fullscreenchange'));
+      await sleep(300);
+
+      return {
+        labelBefore,
+        applied,
+        afterExit: {
+          height: target!.style.height,
+          overflow: target!.style.overflow,
+        },
+      };
+    });
+
+    expect(result.applied.height, 'granted: the target fills the viewport').toBe('100vh');
+    expect(result.applied.label, 'granted: the button offers the way out').toContain('Exit');
+    expect(result.afterExit.height, 'and leaving restores the original height').toBe('');
+    expect(result.afterExit.overflow, 'and the original overflow').toBe('');
+  });
+});


### PR DESCRIPTION
> **John:** "fullscreen is not working"

Reproduced with a real click:

```
document.fullscreenElement : null                 ← nothing went fullscreen
target inline styles       : height: 100vh        ← but stretched anyway
button label               : "✕ Exit Fullscreen"  ← and claiming it worked
```

A panel blown up to viewport height, a control lying about the state, and no error to explain either. Worse than nothing happening.

## Cause

`requestFullscreen()` returns a **promise**. Every side effect was committed before it settled, and the rejection was discarded:

```js
targetEl.style.height = '100vh';
targetEl.requestFullscreen();          // promise ignored
element.textContent = '✕ Exit Fullscreen';
```

The restore path only runs on `fullscreenchange`, which never fires for a request that was rejected — so the wreckage stayed.

## Fix

Request first. Apply the styles and the label only once it resolves. On rejection, restore what was saved **and log the reason** — that reason is exactly what distinguishes "no user gesture" from "blocked by permissions policy" from "this element cannot be fullscreened", and it was being thrown away.

## Verified after, with a real click

| | |
|---|---|
| stage | 220px, no inline styles |
| label | still "⛶ Fullscreen" |

## What I could not verify

**Whether it actually enters fullscreen in a real browser.** In this embedded pane the promise never settles — neither resolve nor reject — so the request just hangs. That's an embedder limitation, not something the page controls. If it still fails to enter for John, the console now names the reason instead of failing mutely.

## A measurement note, because it cost time

My first attempt instrumented `Element.prototype.requestFullscreen` from the devtools context and saw **nothing** on a real click — which looked exactly like the call never happening. It was an isolated-world artifact: a page-world click doesn't go through a prototype patch made in another world. Invoking the handler from the same world showed the call plainly.

## Test plan

`tests/regression/fullscreen-failure-rollback.spec.ts` — **2/2**. The API is stubbed deliberately: whether a given browser grants fullscreen isn't the contract under test — "nothing changes unless it's granted, and a refusal says why" is.

- [x] rejected → height, overflow, measured size and label all unchanged; reason logged
- [x] granted → `100vh` applied, label offers the way out, and leaving restores both

Closes #733