### PR TITLE
fix(#727,#735,#736): 26 specs stopped waiting for a global that never exists; compliance accepts tag-styled hosts

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,15 +27,15 @@
   <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
 
   <!-- Layer 1: Foundation (render-blocking, already highest priority — no preload needed) -->
-  <link rel="stylesheet" href="src/styles/normalize.css?v=269d4e6">
-  <link rel="stylesheet" href="src/styles/themes.css?v=269d4e6">
-  <link rel="stylesheet" href="src/styles/site.css?v=269d4e6">
-  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=269d4e6">
-  <link rel="modulepreload" href="src/core/wb.js?v=269d4e6">
-  <link rel="modulepreload" href="src/core/site-engine.js?v=269d4e6">
+  <link rel="stylesheet" href="src/styles/normalize.css?v=ae39c0f">
+  <link rel="stylesheet" href="src/styles/themes.css?v=ae39c0f">
+  <link rel="stylesheet" href="src/styles/site.css?v=ae39c0f">
+  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=ae39c0f">
+  <link rel="modulepreload" href="src/core/wb.js?v=ae39c0f">
+  <link rel="modulepreload" href="src/core/site-engine.js?v=ae39c0f">
 
   <!-- Page Transitions CSS -->
-  <link rel="stylesheet" href="src/styles/transitions.css?v=269d4e6">
+  <link rel="stylesheet" href="src/styles/transitions.css?v=ae39c0f">
   <!-- Navbar CSS already loads via site.css's own @import — no separate link needed. -->
 
   <!-- Fonts -->
@@ -92,9 +92,9 @@
   </template>
 
   <!-- Premium Navbar Scroll Effect -->
-  <script src="src/lib/premium-navbar.js?v=269d4e6"></script>
+  <script src="src/lib/premium-navbar.js?v=ae39c0f"></script>
 
   <!-- Main Application Bootstrap -->
-  <script type="module" src="./src/main.js?v=269d4e6"></script>
+  <script type="module" src="./src/main.js?v=ae39c0f"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -27,15 +27,15 @@
   <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
 
   <!-- Layer 1: Foundation (render-blocking, already highest priority — no preload needed) -->
-  <link rel="stylesheet" href="src/styles/normalize.css?v=659dd48">
-  <link rel="stylesheet" href="src/styles/themes.css?v=659dd48">
-  <link rel="stylesheet" href="src/styles/site.css?v=659dd48">
-  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=659dd48">
-  <link rel="modulepreload" href="src/core/wb.js?v=659dd48">
-  <link rel="modulepreload" href="src/core/site-engine.js?v=659dd48">
+  <link rel="stylesheet" href="src/styles/normalize.css?v=269d4e6">
+  <link rel="stylesheet" href="src/styles/themes.css?v=269d4e6">
+  <link rel="stylesheet" href="src/styles/site.css?v=269d4e6">
+  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=269d4e6">
+  <link rel="modulepreload" href="src/core/wb.js?v=269d4e6">
+  <link rel="modulepreload" href="src/core/site-engine.js?v=269d4e6">
 
   <!-- Page Transitions CSS -->
-  <link rel="stylesheet" href="src/styles/transitions.css?v=659dd48">
+  <link rel="stylesheet" href="src/styles/transitions.css?v=269d4e6">
   <!-- Navbar CSS already loads via site.css's own @import — no separate link needed. -->
 
   <!-- Fonts -->
@@ -92,9 +92,9 @@
   </template>
 
   <!-- Premium Navbar Scroll Effect -->
-  <script src="src/lib/premium-navbar.js?v=659dd48"></script>
+  <script src="src/lib/premium-navbar.js?v=269d4e6"></script>
 
   <!-- Main Application Bootstrap -->
-  <script type="module" src="./src/main.js?v=659dd48"></script>
+  <script type="module" src="./src/main.js?v=269d4e6"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wb-starter",
-  "version": "3.0.55",
+  "version": "3.0.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wb-starter",
-      "version": "3.0.55",
+      "version": "3.0.56",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wb-starter",
-  "version": "3.0.56",
+  "version": "3.0.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wb-starter",
-      "version": "3.0.56",
+      "version": "3.0.57",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wb-starter",
-  "version": "3.0.55",
+  "version": "3.0.56",
   "type": "module",
   "description": "Modern website starter kit powered by WB Behaviors",
   "main": "index.html",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wb-starter",
-  "version": "3.0.56",
+  "version": "3.0.57",
   "type": "module",
   "description": "Modern website starter kit powered by WB Behaviors",
   "main": "index.html",

--- a/project-index.html
+++ b/project-index.html
@@ -7,8 +7,8 @@
     <title>Project Index</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
-    <link rel="stylesheet" href="src/styles/themes.css?v=269d4e6">
-    <link rel="stylesheet" href="src/styles/site.css?v=269d4e6">
+    <link rel="stylesheet" href="src/styles/themes.css?v=ae39c0f">
+    <link rel="stylesheet" href="src/styles/site.css?v=ae39c0f">
     <script type="module">
       import WB from './src/core/wb.js';
       WB.init({ autoInject: true });

--- a/project-index.html
+++ b/project-index.html
@@ -7,8 +7,8 @@
     <title>Project Index</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
-    <link rel="stylesheet" href="src/styles/themes.css?v=659dd48">
-    <link rel="stylesheet" href="src/styles/site.css?v=659dd48">
+    <link rel="stylesheet" href="src/styles/themes.css?v=269d4e6">
+    <link rel="stylesheet" href="src/styles/site.css?v=269d4e6">
     <script type="module">
       import WB from './src/core/wb.js';
       WB.init({ autoInject: true });

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -3,7 +3,7 @@
  * Regenerated on every commit via .husky/pre-commit.
  */
 export const VERSION = {
-  "version": "3.0.56",
-  "commit": "269d4e6",
-  "builtAt": "2026-08-21T01:21:58.078Z"
+  "version": "3.0.57",
+  "commit": "ae39c0f",
+  "builtAt": "2026-08-21T02:03:07.065Z"
 };

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -3,7 +3,7 @@
  * Regenerated on every commit via .husky/pre-commit.
  */
 export const VERSION = {
-  "version": "3.0.55",
-  "commit": "659dd48",
-  "builtAt": "2026-08-21T01:05:11.350Z"
+  "version": "3.0.56",
+  "commit": "269d4e6",
+  "builtAt": "2026-08-21T01:21:58.078Z"
 };

--- a/tests/behaviors/alerts-variants.spec.ts
+++ b/tests/behaviors/alerts-variants.spec.ts
@@ -1,41 +1,68 @@
 /**
- * #176 — <wb-alert> must honor the `type=` attribute as an alias for `variant`.
- * The showcase authors alerts as `type="success|warning|error"`, but the schema
- * property is `variant` (default "info"), so every alert rendered blue. The
- * schema-builder now supports property aliases (extractData) and the alert schema
- * declares variant.aliases = ["type"].
+ * #176 / #375 / #727 — an alert's variant must be visible.
+ *
+ * Two claims, both of which lost their guard when #664 removed the showcase's
+ * `<wb-demo>` sections:
+ *
+ *   #176 — `type=` is an alias for `variant`, and the four types are four
+ *          colours (they all rendered "info" blue).
+ *   #375 — alert() adds `.wb-alert` AND `.wb-alert--<variant>`; without the
+ *          modifier class every alert rendered unstyled and identical.
+ *
+ * The old version scanned the page for `[x-alert][type="info"]` and failed with
+ * "no alerts found on showcase" — the page builds its examples on demand now.
+ * This drives the panel instead, and reads the rendered example, never a
+ * browse-list row (#727).
  */
 import { test, expect } from '@playwright/test';
+import { openBehaviorsPanel, renderVariant, example, exampleStyle } from '../utils/behaviors-panel';
 
-test('#176 — alert type= maps to variant: four distinct colors', async ({ page }) => {
-  await page.goto('http://localhost:3000/?page=behaviors');
-  await page.waitForSelector('#mainPage-behaviors', { timeout: 20000 });
-  await page.waitForTimeout(2500); // lazy injection + schema build
+const VARIANTS = ['info', 'success', 'warning', 'error'] as const;
 
-  const info = await page.locator('[x-alert][type="info"], [x-alert].wb-alert--info').first();
-  await expect(info, 'no alerts found on showcase').toBeVisible();
+test.describe('#176/#375 — alert variants', () => {
+  test('each variant carries wb-alert and its own modifier class', async ({ page }) => {
+    await openBehaviorsPanel(page, 'x-alert');
 
-  // Each type= alert should carry the matching wb-alert--<type> class…
-  const classMatch = await page.evaluate(() => {
-    const types = ['info', 'success', 'warning', 'error'];
-    return types.map((t) => {
-      const el = document.querySelector(`[x-alert][type="${t}"]`);
-      return { t, hasClass: !!el && el.classList.contains(`wb-alert--${t}`) };
-    });
+    for (const variant of VARIANTS) {
+      await renderVariant(page, 'x-alert', variant);
+      const el = example(page);
+      await expect(el, `${variant}: missing the base class`).toHaveClass(/\bwb-alert\b/);
+      await expect(el, `${variant}: missing wb-alert--${variant}`)
+        .toHaveClass(new RegExp(`\\bwb-alert--${variant}\\b`));
+    }
   });
-  for (const { t, hasClass } of classMatch) {
-    expect(hasClass, `wb-alert[type="${t}"] did not get class wb-alert--${t}`).toBe(true);
-  }
 
-  // …and the four variants must be visually distinct (not all "info" blue).
-  const colors = await page.evaluate(() =>
-    ['info', 'success', 'warning', 'error'].map((t) => {
-      const el = document.querySelector(`[x-alert][type="${t}"]`) as HTMLElement;
-      return el ? getComputedStyle(el).backgroundColor : 'MISSING';
-    })
-  );
-  expect(
-    new Set(colors).size,
-    `alert variants not distinct (type= ignored?): ${colors.join(', ')}`
-  ).toBe(4);
+  test('the four variants render four distinct appearances', async ({ page }) => {
+    await openBehaviorsPanel(page, 'x-alert');
+
+    const seen: Record<string, string> = {};
+    for (const variant of VARIANTS) {
+      await renderVariant(page, 'x-alert', variant);
+      // Alerts colour themselves through background AND border; take both, so a
+      // theme that varies only one still reads as distinct.
+      const bg = await exampleStyle(page, 'background-color');
+      const border = await exampleStyle(page, 'border-color');
+      seen[variant] = `${bg} | ${border}`;
+    }
+
+    const distinct = new Set(Object.values(seen));
+    expect(
+      distinct.size,
+      'expected 4 distinct alert appearances, got:\n' +
+      Object.entries(seen).map(([v, s]) => `  ${v}: ${s}`).join('\n'),
+    ).toBe(VARIANTS.length);
+  });
+
+  test('what is measured is the rendered alert, not a list row', async ({ page }) => {
+    await openBehaviorsPanel(page, 'x-alert');
+    await renderVariant(page, 'x-alert', 'warning');
+
+    const where = await example(page).evaluate((el) => ({
+      insideExample: !!el.closest('#behaviors-live-example'),
+      insideList: !!el.closest('.behaviors-search-results'),
+    }));
+
+    expect(where.insideExample, 'must measure inside the example wrapper').toBe(true);
+    expect(where.insideList, 'must never measure a browse-list row (#727)').toBe(false);
+  });
 });

--- a/tests/behaviors/breadcrumb-render.spec.ts
+++ b/tests/behaviors/breadcrumb-render.spec.ts
@@ -6,7 +6,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'crumb-test-area';

--- a/tests/behaviors/colorpicker-input-target.spec.ts
+++ b/tests/behaviors/colorpicker-input-target.spec.ts
@@ -15,7 +15,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'colorpicker-test-area';

--- a/tests/behaviors/input-variant.spec.ts
+++ b/tests/behaviors/input-variant.spec.ts
@@ -6,7 +6,11 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #727/#691: NOT WBSite. /demos/test-harness.html is a standalone page, not
+  // an SPA route, so window.WBSite is never created there -- this waited the
+  // full 20s and then failed before a single assertion ran. Same bug as
+  // details-summary.spec.ts had. WB.behaviors is the signal that applies, and
+  // setup() calls WB.scan() itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'input-test-area';

--- a/tests/behaviors/media-custom-tags-mapping.spec.ts
+++ b/tests/behaviors/media-custom-tags-mapping.spec.ts
@@ -21,7 +21,10 @@ const PIXEL =
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'media-tags-test-area';

--- a/tests/behaviors/permutation-compliance.spec.ts
+++ b/tests/behaviors/permutation-compliance.spec.ts
@@ -410,8 +410,28 @@ test.describe('Component Compliance', () => {
       const element = await setupTestContainer(page, baseHtml);
       
       if (schema.compliance?.baseClass) {
-        const hasBaseClass = await element.evaluate((el, cls) => el.classList.contains(cls), schema.compliance.baseClass);
-        if (!hasBaseClass) {
+        // #736 -- this generates its markup as the CUSTOM TAG (<wb-alert ...>),
+        // and behaviors deliberately skip the redundant base class on a literal
+        // custom-tag host because the stylesheet targets the tag directly -- the
+        // #448 pattern, written down in the source:
+        //
+        //   // skip the redundant class on a literal <wb-alert> host (its own
+        //   // tag selector already covers it), add it for every other host.
+        //   if (element.tagName.toLowerCase() !== 'wb-alert') element.classList.add('wb-alert');
+        //
+        // Measured: <div x-alert variant="warning"> -> "wb-alert wb-alert--warning",
+        // <wb-alert variant="warning"> -> "wb-alert--warning", and alert.css line
+        // 10 is `wb-alert,`. Both are styled. Asserting the literal class failed
+        // 50 behaviors for doing the right thing.
+        //
+        // What matters is that the element is COVERED by its base style, so the
+        // tag counts. An attribute host missing the class is still a failure --
+        // that is the #375 bug this check exists to catch.
+        const covered = await element.evaluate(
+          (el, cls) => el.classList.contains(cls) || el.tagName.toLowerCase() === cls,
+          schema.compliance.baseClass,
+        );
+        if (!covered) {
           allErrors.push(`[BASE CLASS] Missing: "${schema.compliance.baseClass}"`);
         }
       }
@@ -642,8 +662,16 @@ test.describe('Component Compliance', () => {
               if (visTest.expect.hasClass) {
                 const classes = Array.isArray(visTest.expect.hasClass) ? visTest.expect.hasClass : [visTest.expect.hasClass];
                 for (const cls of classes) {
-                  const hasClass = await target.evaluate((el, c) => el.classList.contains(c), cls);
-                  if (!hasClass) {
+                  // #736, same rule as CHECK 1: a custom-tag host is styled by
+                  // its TAG selector, so behaviors skip the redundant base class
+                  // there (card.js:230 for this exact case). card.schema.json's
+                  // "Basic Card" sets up a <wb-card> and expects "wb-card" --
+                  // covered by the tag, absent as a class, and correct either way.
+                  const covered = await target.evaluate(
+                    (el, c) => el.classList.contains(c) || el.tagName.toLowerCase() === c,
+                    cls,
+                  );
+                  if (!covered) {
                     allErrors.push(`[VISUAL] ${visTest.name}: Missing class "${cls}"`);
                   }
                 }

--- a/tests/behaviors/progress-fill.spec.ts
+++ b/tests/behaviors/progress-fill.spec.ts
@@ -6,7 +6,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'progress-test-area';

--- a/tests/behaviors/progress-striped-not-conflated-with-animated.spec.ts
+++ b/tests/behaviors/progress-striped-not-conflated-with-animated.spec.ts
@@ -14,7 +14,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'progress-striped-test-area';

--- a/tests/behaviors/skeleton-render.spec.ts
+++ b/tests/behaviors/skeleton-render.spec.ts
@@ -6,7 +6,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'skeleton-test-area';

--- a/tests/behaviors/spinner-anim.spec.ts
+++ b/tests/behaviors/spinner-anim.spec.ts
@@ -6,7 +6,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'spinner-test-area';

--- a/tests/behaviors/steps-render.spec.ts
+++ b/tests/behaviors/steps-render.spec.ts
@@ -6,7 +6,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'steps-test-area';

--- a/tests/behaviors/table-bare-attributes.spec.ts
+++ b/tests/behaviors/table-bare-attributes.spec.ts
@@ -9,7 +9,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'table-test-area';

--- a/tests/behaviors/tabs-render.spec.ts
+++ b/tests/behaviors/tabs-render.spec.ts
@@ -6,7 +6,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'tabs-test-area';

--- a/tests/behaviors/toast-color.spec.ts
+++ b/tests/behaviors/toast-color.spec.ts
@@ -6,7 +6,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'toast-test-area';

--- a/tests/behaviors/wb-button-effect.spec.ts
+++ b/tests/behaviors/wb-button-effect.spec.ts
@@ -20,7 +20,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string, id = 'wb-button-effect-area'): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate(({ h, containerId }) => {
     const c = document.createElement('div');
     c.id = containerId;

--- a/tests/behaviors/wb-card-link-real-anchor.spec.ts
+++ b/tests/behaviors/wb-card-link-real-anchor.spec.ts
@@ -14,7 +14,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'cardlink-test-area';

--- a/tests/behaviors/wb-figure-tag-mapping.spec.ts
+++ b/tests/behaviors/wb-figure-tag-mapping.spec.ts
@@ -19,7 +19,10 @@ const PIXEL =
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate(async (h: string) => {
     const c = document.createElement('div');
     c.id = 'figure-test-area';

--- a/tests/behaviors/wb-image-bare-attributes.spec.ts
+++ b/tests/behaviors/wb-image-bare-attributes.spec.ts
@@ -15,7 +15,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'image-test-area';

--- a/tests/behaviors/wb-progress-animated-indeterminate.spec.ts
+++ b/tests/behaviors/wb-progress-animated-indeterminate.spec.ts
@@ -12,7 +12,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'progress-anim-test-area';

--- a/tests/behaviors/wb-search-select-effect.spec.ts
+++ b/tests/behaviors/wb-search-select-effect.spec.ts
@@ -19,7 +19,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'test-area';

--- a/tests/behaviors/wb-slider-rating-range-effect.spec.ts
+++ b/tests/behaviors/wb-slider-rating-range-effect.spec.ts
@@ -19,7 +19,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'wb-slider-rating-range-test-area';

--- a/tests/behaviors/wb-switch-textarea-effect.spec.ts
+++ b/tests/behaviors/wb-switch-textarea-effect.spec.ts
@@ -51,7 +51,10 @@ import { test, expect, Page } from '@playwright/test';
 async function setup(page: Page, html: string): Promise<void> {
   await page.goto('/demos/test-harness.html');
   await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 15000 });
-  await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
   await page.evaluate((h: string) => {
     const c = document.createElement('div');
     c.id = 'wb-switch-textarea-test-area';

--- a/tests/compliance/behaviors-live-examples-layout.spec.ts
+++ b/tests/compliance/behaviors-live-examples-layout.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * #693 — DEMOS-AND-DOCS-STANDARDS.md §13 for the behaviors page's LIVE examples.
+ *
+ * demo-layout-standards.spec.ts enforces §13 by parsing `<wb-demo>` blocks out
+ * of demos/**\/*.html and pages/**\/*.html. Since #664 the behaviors page does
+ * not author its examples — all 585 are built from the x-* registry at runtime
+ * and rendered into #behaviors-live-stage when a row is picked. There is no
+ * <wb-demo> block for that sweep to find, so none of them were ever checked.
+ * That is how the `details` example shipped with its content flush against the
+ * border (#689).
+ *
+ * Scope: container-like examples only — an example root that has element
+ * children AND a visible border or background. A bare <button>, chip or badge
+ * has no element children and is deliberately out of scope; that carve-out is
+ * what #685 is still arguing about and this test must not re-litigate it.
+ *
+ * Rule: no text may render within 1rem of the example root's own edge. Same
+ * measure as demo-layout-standards.spec.ts's MIN_TEXT_EDGE_PX, applied to the
+ * rendered result instead of the authored markup.
+ */
+import { test, expect, Page } from '@playwright/test';
+
+const MIN_TEXT_EDGE_PX = 15;   // 1rem at the default root size, minus rounding slack
+const SLICES = 6;              // split the 585 rows so no single test runs long
+
+type Violation = { token: string; variant: string; tag: string; worstPx: number };
+
+async function openBrowseList(page: Page) {
+  await page.goto('/?page=behaviors');
+  await page.waitForSelector('#behaviors-search', { timeout: 30000 });
+  await page.fill('#behaviors-search', 'x-');
+  await page.waitForFunction(
+    () => document.querySelectorAll('.behaviors-search-results__row').length > 0,
+    { timeout: 30000 },
+  );
+}
+
+/**
+ * Measures one row's rendered example. Returns null when the example is not
+ * container-like (out of scope) or rendered nothing.
+ */
+async function measureRow(page: Page, index: number): Promise<Violation | null> {
+  return page.evaluate(async (i: number) => {
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+    const rows = [...document.querySelectorAll('.behaviors-search-results__row')] as HTMLElement[];
+    const row = rows[i];
+    if (!row) return null;
+
+    row.click();
+    await sleep(40);
+
+    const stage = document.getElementById('behaviors-live-stage');
+    const root = stage?.firstElementChild as HTMLElement | undefined;
+    if (!root) return null;
+
+    // Out of scope: bare controls with no element children, and anything with
+    // no surface of its own to pad against.
+    if (root.children.length === 0) return null;
+    const cs = getComputedStyle(root);
+    const hasSurface = parseFloat(cs.borderTopWidth) > 0
+      || (cs.backgroundColor !== 'rgba(0, 0, 0, 0)' && cs.backgroundColor !== 'transparent');
+    if (!hasSurface) return null;
+
+    const rb = root.getBoundingClientRect();
+    if (rb.width === 0 || rb.height === 0) return null;
+
+    let worst = Number.POSITIVE_INFINITY;
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+    let node: Node | null;
+    while ((node = walker.nextNode())) {
+      if (!node.nodeValue || !node.nodeValue.trim()) continue;
+      const range = document.createRange();
+      range.selectNodeContents(node);
+      for (const t of Array.from(range.getClientRects())) {
+        if (t.width <= 0 || t.height <= 0) continue;
+        worst = Math.min(worst, t.left - rb.left, rb.right - t.right, t.top - rb.top, rb.bottom - t.bottom);
+      }
+    }
+    if (!Number.isFinite(worst)) return null;   // container renders no text
+
+    return {
+      token: row.getAttribute('data-browse-token') || '?',
+      variant: row.getAttribute('data-variant') || '',
+      tag: root.tagName.toLowerCase(),
+      worstPx: Math.round(worst),
+    };
+  }, index);
+}
+
+for (let slice = 0; slice < SLICES; slice++) {
+  test(`§13: live examples ${slice + 1}/${SLICES} keep text 1rem clear of their own edge`, async ({ page }) => {
+    test.setTimeout(180_000);
+    await openBrowseList(page);
+
+    const total = await page.evaluate(
+      () => document.querySelectorAll('.behaviors-search-results__row').length,
+    );
+    const per = Math.ceil(total / SLICES);
+    const start = slice * per;
+    const end = Math.min(start + per, total);
+
+    const violations: Violation[] = [];
+    for (let i = start; i < end; i++) {
+      const result = await measureRow(page, i);
+      if (result && result.worstPx < MIN_TEXT_EDGE_PX) violations.push(result);
+
+      // Some behaviors open a dialog, drawer or overlay when they render.
+      // Escape clears them so the next row is measured against its own output.
+      await page.keyboard.press('Escape').catch(() => {});
+
+      // Toasts, confetti and stagelight overlays accumulate; start clean
+      // periodically rather than measuring through someone else's leftovers.
+      if ((i - start) > 0 && (i - start) % 60 === 0) await openBrowseList(page);
+    }
+
+    const report = violations
+      .map((v) => `  ${v.token}${v.variant ? ` (${v.variant})` : ''} — <${v.tag}> text ${v.worstPx}px from its edge`)
+      .join('\n');
+
+    expect(
+      violations,
+      violations.length
+        ? `§13 requires >=1rem between an example container's edge and its text.\n${report}`
+        : '',
+    ).toHaveLength(0);
+  });
+}

--- a/tests/regression/wb-btn-bare-class-audit.spec.ts
+++ b/tests/regression/wb-btn-bare-class-audit.spec.ts
@@ -121,7 +121,10 @@ test.describe('Bare .wb-btn (no modifier) renders with real visible styling', ()
     test.beforeEach(async ({ page }) => {
       await page.goto('/?page=behaviors');
       await page.waitForFunction(() => (window as any).WB && (window as any).WB.behaviors, { timeout: 20000 });
-      await page.waitForFunction(() => (window as any).WBSite && (window as any).WBSite.currentPage, { timeout: 20000 });
+  // #735: NOT WBSite. This page is a standalone harness, not an SPA route, so
+  // window.WBSite is never created here -- the wait burned its full timeout and
+  // failed before a single assertion ran. WB.behaviors is the readiness signal
+  // that applies, and this setup scans the DOM itself below.
       await page.waitForTimeout(1000);
     });
 

--- a/tests/utils/behaviors-panel.ts
+++ b/tests/utils/behaviors-panel.ts
@@ -1,0 +1,107 @@
+/**
+ * behaviors-panel.ts (#727)
+ *
+ * Drives the behaviors showcase the way a reader does: search a token, pick a
+ * variant row, read what renders in the live panel.
+ *
+ * Before #664 the page hosted every example as a `<wb-demo>` section, and specs
+ * scanned the page for them. Those sections are gone, so five variant specs
+ * were scanning for elements that no longer exist — and one of them,
+ * `button-size-variant-classes`, located buttons by `hasText: 'Primary'`, which
+ * now matches the browse-list ROWS (whose variant column reads "primary").
+ * Identical by design, so it "measured" three identical backgrounds. A test
+ * pointing at the wrong elements is worse than one that fails outright.
+ *
+ * Everything here reads from inside `#behaviors-live-example` for that reason —
+ * the rendered example, never a list row.
+ */
+import { expect, Page, Locator } from '@playwright/test';
+
+export const EXAMPLE_ROOT = '#behaviors-live-example';
+
+/** Load the showcase and filter the list to one behavior. */
+export async function openBehaviorsPanel(page: Page, token: string): Promise<void> {
+  await page.goto('/?page=behaviors');
+  await page.waitForSelector('#behaviors-search', { timeout: 30000 });
+  await page.fill('#behaviors-search', token);
+  await page.waitForFunction(
+    (t) => [...document.querySelectorAll('.behaviors-search-results__row')]
+      .some((r) => r.getAttribute('data-browse-token') === t),
+    token,
+    { timeout: 30000 },
+  );
+}
+
+/** Every variant this behavior offers, in list order. */
+export async function variantsOf(page: Page, token: string): Promise<string[]> {
+  return page.evaluate((t) =>
+    [...document.querySelectorAll('.behaviors-search-results__row')]
+      .filter((r) => r.getAttribute('data-browse-token') === t)
+      .map((r) => r.getAttribute('data-variant') || ''),
+    token,
+  );
+}
+
+/**
+ * Render one variant and wait for it to appear in the panel.
+ * Throws if that behavior has no such variant row, rather than silently
+ * measuring whatever happened to be on screen.
+ */
+export async function renderVariant(page: Page, token: string, variant: string): Promise<void> {
+  // Wait for THIS row, not just any row for the token: openBehaviorsPanel
+  // returns as soon as one match exists, and the list is still filling in.
+  // Without this the first variant asked for could be missing purely because it
+  // had not rendered yet -- which read as "no such variant" and was wrong.
+  await page.waitForFunction(
+    ({ t, v }) => [...document.querySelectorAll('.behaviors-search-results__row')]
+      .some((r) => r.getAttribute('data-browse-token') === t
+                && r.getAttribute('data-variant') === v),
+    { t: token, v: variant },
+    { timeout: 15000 },
+  ).catch(() => { /* fall through to the explicit assertion below */ });
+
+  const picked = await page.evaluate(({ t, v }) => {
+    const row = [...document.querySelectorAll('.behaviors-search-results__row')]
+      .find((r) => r.getAttribute('data-browse-token') === t
+                && r.getAttribute('data-variant') === v) as HTMLElement | undefined;
+    if (!row) return false;
+    row.click();
+    return true;
+  }, { t: token, v: variant });
+
+  expect(picked, `no ${token} row with variant "${variant}" in the browse list`).toBe(true);
+  await page.waitForFunction(
+    (sel) => !!document.querySelector(`${sel} > *`),
+    EXAMPLE_ROOT,
+    { timeout: 10000 },
+  );
+  await page.waitForTimeout(250);
+}
+
+/** The rendered example's root element — never a list row. */
+export function example(page: Page): Locator {
+  return page.locator(`${EXAMPLE_ROOT} > *`).first();
+}
+
+/** A computed style of the rendered example. */
+export async function exampleStyle(page: Page, prop: string): Promise<string> {
+  return example(page).evaluate(
+    (el, p) => getComputedStyle(el).getPropertyValue(p),
+    prop,
+  );
+}
+
+/** Render each variant in turn and collect one computed value from each. */
+export async function styleAcrossVariants(
+  page: Page,
+  token: string,
+  variants: string[],
+  prop: string,
+): Promise<Record<string, string>> {
+  const out: Record<string, string> = {};
+  for (const v of variants) {
+    await renderVariant(page, token, v);
+    out[v] = await exampleStyle(page, prop);
+  }
+  return out;
+}


### PR DESCRIPTION
Three test-side root causes behind a large share of the behaviors-suite failures. No product code changes.

## #736 — `permutation-compliance`: 95 failures → 0

The single biggest failing spec: **95 of 145 tests**, across 50 behaviors, all on the *first* check:

```
alert compliance failures:
[BASE CLASS] Missing: "wb-alert"
```

It was asserting against a deliberate design. The spec generates its markup as the **custom tag**, and behaviors skip the redundant base class on a custom-tag host because the stylesheet targets the tag — the #448 pattern, with the reasoning already in the source:

```js
// skip the redundant class on a literal <wb-alert> host (its own tag
// selector already covers it), add it for every other host.
if (element.tagName.toLowerCase() !== 'wb-alert') element.classList.add('wb-alert');
```

Measured both forms:

| markup | class list | styled by |
|---|---|---|
| `<div x-alert variant="warning">` | `wb-alert wb-alert--warning` | class |
| `<wb-alert variant="warning">` | `wb-alert--warning` | tag selector (`alert.css:10`) |

Both checks now ask whether the element is **covered** by its base style — has the class, or *is* the tag. An attribute host missing its class still fails, which is the #375 bug these exist to catch.

**145/145 passing.**

## #735 — 26 specs waited 20s for `WBSite` on the standalone harness

```js
await page.goto('/demos/test-harness.html');
await page.waitForFunction(() => window.WBSite && window.WBSite.currentPage, { timeout: 20000 });
```

That page never boots the site engine, so `WBSite` is never defined. Every one of those specs timed out **before a single assertion ran**.

#691 fixed this in one file and I didn't check whether it was systemic. It was: 4 files already carried the fix *with comments explaining it*, and 20 more had been left behind. All 20 patched.

`media-custom-tags-mapping`: **0 passed / 12 failures → 6/6**.

## #727 — `alerts-variants` rewritten to drive the live panel

It scanned the page for `[x-alert][type="info"]` and failed with "no alerts found on showcase" — those sections went in #664. It now selects each variant row and reads the rendered example, and asserts what it measured is inside `#behaviors-live-example` and **not** inside `.behaviors-search-results` — the mistake `button-size-variant-classes` still makes, where `hasText: 'Primary'` matches browse-list rows.

**3/3 — and the four alert variants do render four distinct appearances**, so the product was fine and only the guard was broken.

`tests/utils/behaviors-panel.ts` is the shared driver so the remaining variant specs don't each reinvent it. It waits for the **specific** variant row before clicking — waiting for "any row for this token" raced the list still filling in and reported a present variant as missing.

Closes #735
Closes #736