### PR TITLE
fix(#738): the fullscreen button reports the browser's state, not its own guess

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,15 +27,15 @@
   <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
 
   <!-- Layer 1: Foundation (render-blocking, already highest priority — no preload needed) -->
-  <link rel="stylesheet" href="src/styles/normalize.css?v=ae39c0f">
-  <link rel="stylesheet" href="src/styles/themes.css?v=ae39c0f">
-  <link rel="stylesheet" href="src/styles/site.css?v=ae39c0f">
-  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=ae39c0f">
-  <link rel="modulepreload" href="src/core/wb.js?v=ae39c0f">
-  <link rel="modulepreload" href="src/core/site-engine.js?v=ae39c0f">
+  <link rel="stylesheet" href="src/styles/normalize.css?v=6e67f4c">
+  <link rel="stylesheet" href="src/styles/themes.css?v=6e67f4c">
+  <link rel="stylesheet" href="src/styles/site.css?v=6e67f4c">
+  <link rel="stylesheet" href="src/styles/safari-fixes.css?v=6e67f4c">
+  <link rel="modulepreload" href="src/core/wb.js?v=6e67f4c">
+  <link rel="modulepreload" href="src/core/site-engine.js?v=6e67f4c">
 
   <!-- Page Transitions CSS -->
-  <link rel="stylesheet" href="src/styles/transitions.css?v=ae39c0f">
+  <link rel="stylesheet" href="src/styles/transitions.css?v=6e67f4c">
   <!-- Navbar CSS already loads via site.css's own @import — no separate link needed. -->
 
   <!-- Fonts -->
@@ -92,9 +92,9 @@
   </template>
 
   <!-- Premium Navbar Scroll Effect -->
-  <script src="src/lib/premium-navbar.js?v=ae39c0f"></script>
+  <script src="src/lib/premium-navbar.js?v=6e67f4c"></script>
 
   <!-- Main Application Bootstrap -->
-  <script type="module" src="./src/main.js?v=ae39c0f"></script>
+  <script type="module" src="./src/main.js?v=6e67f4c"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wb-starter",
-  "version": "3.0.57",
+  "version": "3.0.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wb-starter",
-      "version": "3.0.57",
+      "version": "3.0.58",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wb-starter",
-  "version": "3.0.57",
+  "version": "3.0.58",
   "type": "module",
   "description": "Modern website starter kit powered by WB Behaviors",
   "main": "index.html",

--- a/project-index.html
+++ b/project-index.html
@@ -7,8 +7,8 @@
     <title>Project Index</title>
     <link rel="icon" type="image/svg+xml" href="favicon.svg">
     <link rel="apple-touch-icon" href="assets/icons/icon-192.png">
-    <link rel="stylesheet" href="src/styles/themes.css?v=ae39c0f">
-    <link rel="stylesheet" href="src/styles/site.css?v=ae39c0f">
+    <link rel="stylesheet" href="src/styles/themes.css?v=6e67f4c">
+    <link rel="stylesheet" href="src/styles/site.css?v=6e67f4c">
     <script type="module">
       import WB from './src/core/wb.js';
       WB.init({ autoInject: true });

--- a/src/core/version.js
+++ b/src/core/version.js
@@ -3,7 +3,7 @@
  * Regenerated on every commit via .husky/pre-commit.
  */
 export const VERSION = {
-  "version": "3.0.57",
-  "commit": "ae39c0f",
-  "builtAt": "2026-08-21T02:03:07.065Z"
+  "version": "3.0.58",
+  "commit": "6e67f4c",
+  "builtAt": "2026-08-21T02:11:27.749Z"
 };

--- a/src/wb-viewmodels/helpers.js
+++ b/src/wb-viewmodels/helpers.js
@@ -211,7 +211,23 @@ export function fullscreen(element, options = {}) {
   
   let originalStyles = {};
   
-  // Handle fullscreen change events to restore styles
+  // #738 -- John, with the button reading "Exit Fullscreen": "neither fullscreen
+  // or exit work". Both directions look broken for ONE reason: the label was set
+  // from the request's outcome instead of the browser's actual state. Once it
+  // said "Exit" while document.fullscreenElement was null, the next click took
+  // the ENTER branch again (the exit branch is gated on fullscreenElement), so
+  // exiting became unreachable.
+  //
+  // The label is now driven only from fullscreenchange, off the one source of
+  // truth. That also covers Escape, which fires the event with no click at all --
+  // a label managed in the click handler goes out of sync the first time anyone
+  // presses it.
+  const syncLabel = () => {
+    element.textContent = document.fullscreenElement === targetEl
+      ? '✕ Exit Fullscreen'
+      : config.label;
+  };
+
   const handleFullscreenChange = () => {
     if (!document.fullscreenElement) {
       // Exiting fullscreen - restore original styles
@@ -220,8 +236,8 @@ export function fullscreen(element, options = {}) {
         targetEl.style.overflowY = originalStyles.overflowY || '';
         targetEl.style.height = originalStyles.height || '';
       }
-      element.textContent = '⛶ Fullscreen';
     }
+    syncLabel();
   };
   
   document.addEventListener('fullscreenchange', handleFullscreenChange);
@@ -262,11 +278,22 @@ export function fullscreen(element, options = {}) {
 
     Promise.resolve(request)
       .then(() => {
+        // #738: resolving is not the same as being fullscreen. Check the actual
+        // state before committing anything -- a resolve that did not put THIS
+        // element in the top layer would otherwise leave a stretched panel and a
+        // button offering an exit that cannot work.
+        if (document.fullscreenElement !== targetEl) {
+          console.error('[WB:fullscreen] request resolved but',
+            JSON.stringify(config.target || 'documentElement'),
+            'is not the fullscreen element — leaving everything as it was');
+          syncLabel();
+          return;
+        }
         originalStyles = saved;
         targetEl.style.overflow = 'auto';
         targetEl.style.overflowY = 'auto';
         targetEl.style.height = '100vh';
-        element.textContent = '✕ Exit Fullscreen';
+        syncLabel();
       })
       .catch((err) => {
         // Nothing was changed, so there is nothing to undo -- but SAY why.
@@ -277,7 +304,7 @@ export function fullscreen(element, options = {}) {
         targetEl.style.overflow = saved.overflow;
         targetEl.style.overflowY = saved.overflowY;
         targetEl.style.height = saved.height;
-        element.textContent = config.label;
+        syncLabel();
       });
   };
 

--- a/tests/regression/fullscreen-failure-rollback.spec.ts
+++ b/tests/regression/fullscreen-failure-rollback.spec.ts
@@ -33,8 +33,12 @@ test.describe('#733 — a refused fullscreen changes nothing', () => {
 
     const result = await page.evaluate(async () => {
       const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-      const target = document.getElementById('behaviors-live-stage')
-        || document.getElementById('behaviors-live-example');
+      // The EXAMPLE WRAPPER is what x-fullscreen targets since #722 -- the stage
+      // is the panel-sized surface around it. Checking the stage first measured
+      // the wrong element: the wrapper got height:100vh while the stage stayed
+      // empty, and the test read "" and called the grant a failure.
+      const target = document.getElementById('behaviors-live-example')
+        || document.getElementById('behaviors-live-stage');
       const btn = document.getElementById('behaviors-live-fullscreen') as HTMLElement;
 
       const before = {
@@ -83,13 +87,26 @@ test.describe('#733 — a refused fullscreen changes nothing', () => {
 
     const result = await page.evaluate(async () => {
       const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
-      const target = document.getElementById('behaviors-live-stage')
-        || document.getElementById('behaviors-live-example');
+      // The EXAMPLE WRAPPER is what x-fullscreen targets since #722 -- the stage
+      // is the panel-sized surface around it. Checking the stage first measured
+      // the wrong element: the wrapper got height:100vh while the stage stayed
+      // empty, and the test read "" and called the grant a failure.
+      const target = document.getElementById('behaviors-live-example')
+        || document.getElementById('behaviors-live-stage');
       const btn = document.getElementById('behaviors-live-fullscreen') as HTMLElement;
       const labelBefore = btn.textContent!.trim();
 
+      // A GENUINE grant: resolve AND put the element in the top layer. #738
+      // made the code check `document.fullscreenElement === targetEl` before
+      // committing, so a bare resolve is (correctly) refused now -- faking only
+      // the promise would be testing the refusal path, not this one.
       const origRequest = Element.prototype.requestFullscreen;
-      Element.prototype.requestFullscreen = function () { return Promise.resolve(); };
+      Element.prototype.requestFullscreen = function (this: Element) {
+        Object.defineProperty(document, 'fullscreenElement', {
+          configurable: true, get: () => this,
+        });
+        return Promise.resolve();
+      };
 
       btn.onclick!(new MouseEvent('click'));
       await sleep(400);
@@ -102,6 +119,9 @@ test.describe('#733 — a refused fullscreen changes nothing', () => {
       };
 
       // Coming back out restores what was saved (#720's guarantee).
+      Object.defineProperty(document, 'fullscreenElement', {
+        configurable: true, get: () => null,
+      });
       document.dispatchEvent(new Event('fullscreenchange'));
       await sleep(300);
 
@@ -119,5 +139,80 @@ test.describe('#733 — a refused fullscreen changes nothing', () => {
     expect(result.applied.label, 'granted: the button offers the way out').toContain('Exit');
     expect(result.afterExit.height, 'and leaving restores the original height').toBe('');
     expect(result.afterExit.overflow, 'and the original overflow').toBe('');
+  });
+});
+
+test.describe('#738 — the label never lies about the state', () => {
+  test('a resolve that did not actually go fullscreen is caught and reported', async ({ page }) => {
+    await openExample(page);
+
+    const result = await page.evaluate(async () => {
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      const target = document.getElementById('behaviors-live-example')
+        || document.getElementById('behaviors-live-stage');
+      const btn = document.getElementById('behaviors-live-fullscreen') as HTMLElement;
+      const labelBefore = btn.textContent!.trim();
+
+      const errors: string[] = [];
+      const origError = console.error;
+      console.error = (...a: any[]) => { errors.push(a.join(' ')); origError(...a); };
+
+      // Resolve WITHOUT the browser actually entering fullscreen — the exact
+      // state John hit: a button offering an exit that could never run, because
+      // the exit branch is gated on document.fullscreenElement.
+      const origRequest = Element.prototype.requestFullscreen;
+      Element.prototype.requestFullscreen = function () { return Promise.resolve(); };
+
+      btn.onclick!(new MouseEvent('click'));
+      await sleep(400);
+
+      Element.prototype.requestFullscreen = origRequest;
+      console.error = origError;
+
+      return {
+        labelBefore,
+        labelAfter: btn.textContent!.trim(),
+        height: target!.style.height,
+        reported: errors.some((e) => e.includes('[WB:fullscreen]') && e.includes('not the fullscreen element')),
+        fullscreenElement: document.fullscreenElement ? 'set' : 'null',
+      };
+    });
+
+    expect(result.fullscreenElement, 'the premise: nothing is actually fullscreen').toBe('null');
+    expect(result.labelAfter, 'the button must not offer an exit that cannot work')
+      .toBe(result.labelBefore);
+    expect(result.height, 'and nothing may be stretched').toBe('');
+    expect(result.reported, 'the mismatch must be reported').toBe(true);
+  });
+
+  test('leaving by Escape resets the label', async ({ page }) => {
+    await openExample(page);
+
+    const label = await page.evaluate(async () => {
+      const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+      const target = document.getElementById('behaviors-live-example')
+        || document.getElementById('behaviors-live-stage');
+      const btn = document.getElementById('behaviors-live-fullscreen') as HTMLElement;
+
+      // Pretend the browser really did enter fullscreen on our target...
+      Object.defineProperty(document, 'fullscreenElement', {
+        configurable: true, get: () => target,
+      });
+      document.dispatchEvent(new Event('fullscreenchange'));
+      await sleep(200);
+      const whileIn = btn.textContent!.trim();
+
+      // ...then Escape: fullscreenchange fires with NO click involved.
+      Object.defineProperty(document, 'fullscreenElement', {
+        configurable: true, get: () => null,
+      });
+      document.dispatchEvent(new Event('fullscreenchange'));
+      await sleep(200);
+
+      return { whileIn, afterEscape: btn.textContent!.trim() };
+    });
+
+    expect(label.whileIn, 'in fullscreen the button offers the way out').toContain('Exit');
+    expect(label.afterEscape, 'Escape must put the label back — no click happens').not.toContain('Exit');
   });
 });


### PR DESCRIPTION
Closes #738.

John, with a screenshot of the button reading "Exit Fullscreen": **"neither fullscreen or exit work"**. Both directions look broken for one reason.

## The bug

The label was set from the **request's outcome**, not from the browser. Once it said "Exit" while `document.fullscreenElement` was `null`, the next click took the **enter** branch again — the exit branch is gated on `document.fullscreenElement` — so exiting became unreachable. A lying label makes the exit path impossible to hit, which is exactly what "neither works" looks like from the outside.

## The fix

- The label is now derived **only** from `document.fullscreenElement === targetEl`, driven by the `fullscreenchange` event. That also covers **Escape**, which fires the event with no click at all — a label managed inside the click handler goes out of sync the first time anyone presses it.
- Resolving is not the same as being fullscreen. The `.then()` now verifies the target really is the fullscreen element before committing any styles, and reports the mismatch instead of leaving a stretched panel behind a button that cannot work.

## Two of my own tests were wrong

Corrected here, not worked around:

1. The "granted" case stubbed a resolve **without** setting `fullscreenElement`. #738 makes the code (correctly) refuse that — so the test was exercising the refusal path while claiming to test the grant. It now fakes a genuine grant: resolve **and** put the element in the top layer.
2. Both tests resolved their target stage-first (`behaviors-live-stage || behaviors-live-example`), but #722 moved the fullscreen target to the example **wrapper**. They measured the stage — which correctly stayed empty — read `""`, and called a working grant a failure. Written before #722 landed, never updated.

## Verification

`fullscreen-failure-rollback.spec.ts` — **4/4 passing**:
- a refused request changes nothing and logs why
- a genuine grant applies `100vh` and restores on exit
- a resolve that did not go fullscreen is caught and reported
- Escape resets the label

Also confirmed by hand in the browser on the real path: `fullscreenElementIsTarget: true`, `height: "100vh"`, `label: "✕ Exit Fullscreen"`, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)